### PR TITLE
Add snowplow_mobile_delete_from_manifest macro (Close #54)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+snowplow-utils 0.6.0 (2022-01-31)
+---------------------------------------
+Add snowplow_mobile_delete_from_manifest macro (Close #54)
+
 snowplow-utils 0.5.0 (2021-12-16)
 ---------------------------------------
 Add dbt v1 compatibility (Close #52)

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils'
-version: '0.5.0'
+version: '0.6.0'
 config-version: 2
 
 require-dbt-version: [">=0.20.0", "<1.1.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils_integration_tests'
-version: '0.5.0'
+version: '0.6.0'
 config-version: 2
 
 profile: 'integration_tests'

--- a/macros/utils/snowplow_delete_from_manifest.sql
+++ b/macros/utils/snowplow_delete_from_manifest.sql
@@ -59,3 +59,9 @@
   {{ snowplow_utils.snowplow_delete_from_manifest(models, ref('snowplow_web_incremental_manifest')) }}
 
 {% endmacro %}
+
+{% macro snowplow_mobile_delete_from_manifest(models) %}
+
+  {{ snowplow_utils.snowplow_delete_from_manifest(models, ref('snowplow_mobile_incremental_manifest')) }}
+
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation
Add the `snowplow_mobile_delete_from_manifest` macro to the list of supported macros, which is the `mobile` counterpart to the already existing `snowplow_web_delete_from_manifest` macro.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
