### PR TITLE
Add a type_string macro to generate a varchar type (Close #65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Includes:
 - [n_timedeltas_ago](#n_timedeltas_ago-source)
 - [type_string](#type_string-source)
 - [type_max_string](#type_max_string-source)
+- [timestamp_diff](#timestamp_diff-source)
+- [timestamp_add](#timestamp_add-source)
+- [cast_to_tstamp](#cast_to_tstamp-source)
+- [to_unixtstamp](#to_unixtstamp-source)
 
 **[Materializations](#materializations)**
 
@@ -335,6 +339,84 @@ This macro generates a varchar of the maximum length for each supported database
 **Returns:**
 
 - The database equivalent of a string datatype with the maximum allowed length 
+
+### timestamp_diff ([source](macros/utils/cross_db/timestamp_functions.sql))
+
+This macro mimics the utility of the dbt_utils version however for BigQuery it ensures that the timestamp difference is calculated, similar to the other DB engines which is not the case in the dbt_utils macro. This macro calculates the difference between two dates. Note: The datepart argument is database-specific.
+
+**Arguments:**
+
+- `first_stamp`: The earlier timestamp to subtract by
+- `second_tstamp`: The later timestamp to subtract from
+- `datepart`: The unit of time that the result is denoted it
+
+**Usage:**
+
+```sql
+{{ snowplow_utils.timestamp_diff('2022-01-10 10:23:02', '2022-01-14 09:40:56', 'day') }}
+```
+
+**Returns:**
+
+- The timestamp difference between two fields denoted in the requested unit
+
+### timestamp_add ([source](macros/utils/cross_db/timestamp_functions.sql))
+
+This macro mimics the utility of the dbt_utils version however for BigQuery it ensures that the timestamp difference is calculated, similar to the other DB engines which is not the case in the dbt_utils macro. This macro adds a date/time interval to the supplied date/timestamp. Note: The datepart argument is database-specific.
+
+
+**Arguments:**
+
+- `datepart`: The date/time type of interval to be added
+- `interval`: The amount of time of the datepart to be added
+- `tstamp`: The timestamp to add the interval to
+
+**Usage:**
+
+```sql
+{{ snowplow_utils.timestamp_add('day', 5, '2022-02-01 10:05:32') }}
+```
+
+**Returns:**
+
+- The new timestamp that results in adding the interval to the provided timestamp.
+
+### cast_to_tstamp ([source](macros/utils/cross_db/timestamp_functions.sql))
+
+This macro casts a column to a timestamp across databases. It is an adaptation of the `dbt_utils.type_timestamp()` macro.
+
+**Arguments:**
+
+- `tstamp_literal`: The column that is to be cast to a tstamp data type
+
+**Usage:**
+
+```sql
+{{ snowplow_utils.cast_to_tstamp('events.collector_tstamp') }}
+```
+
+**Returns:**
+
+- The field as a timestamp
+
+### to_unixtstamp ([source](macros/utils/cross_db/timestamp_functions.sql))
+
+This macro casts a column to a unix timestamp across databases.
+
+**Arguments:**
+
+- `tstamp`: The column that is to be cast to a unix timestamp
+
+**Usage:**
+
+```sql
+{{ snowplow_utils.to_unixtstamp('events.collector_tstamp') }}
+```
+
+**Returns:**
+
+- The field as a unix timestamp
+
 
 ## Materializations
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Includes:
 - [snowplow_mobile_delete_from_manifest](#snowplow_mobile_delete_from_manifest-source)
 - [get_value_by_target](#get_value_by_target-source)
 - [n_timedeltas_ago](#n_timedeltas_ago-source)
+- [type_string](#type_string-source)
+- [type_max_string](#type_max_string-source)
 
 **[Materializations](#materializations)**
 
@@ -300,6 +302,39 @@ vars:
                                       default_value='2020-01-01', 
                                       dev_target_name='dev') }}"
 ```
+
+### type_string ([source](macros/utils/cross_db/datatypes.sql))
+
+This macro takes the length of a string type as defined by the `max_characters` variable, and generates a varchar of that specified length for each supported database. While for most databases this does not affect performance, it can affect storage when compared to using a varchar of the maximum length.
+
+**Arguments:**
+
+- `max_characters`: The length of the varchar you want to create
+
+**Usage:**
+
+```sql
+{{ snowplow_utils.type_string(16) }}
+```
+
+**Returns:**
+
+- The database equivalent of a string datatype with a specified length (BQ doesn't have a varchar type)
+
+### type_max_string ([source](macros/utils/cross_db/datatypes.sql))
+
+This macro generates a varchar of the maximum length for each supported database. While for most databases this does not affect performance, it can affect storage when compared to using a varchar of a predefined length.
+
+
+**Usage:**
+
+```sql
+{{ snowplow_utils.type_max_string() }}
+```
+
+**Returns:**
+
+- The database equivalent of a string datatype with the maximum allowed length 
 
 ## Materializations
 

--- a/macros/utils/cross_db/datatypes.sql
+++ b/macros/utils/cross_db/datatypes.sql
@@ -1,0 +1,33 @@
+{# string  -------------------------------------------------     #}
+
+{%- macro type_string(max_characters) -%}
+  {{ return(adapter.dispatch('type_string', 'snowplow_utils')(max_characters)) }}
+{%- endmacro -%}
+
+{% macro default__type_string(max_characters) %}
+    varchar( {{max_characters }} )
+{% endmacro %}
+
+{% macro bigquery__type_string(max_characters) %}
+    string
+{% endmacro %}
+
+{%- macro type_max_string() -%}
+  {{ return(adapter.dispatch('type_max_string', 'snowplow_utils')()) }}
+{%- endmacro -%}
+
+{% macro default__type_max_string() %}
+    string
+{% endmacro %}
+
+{% macro snowflake__type_max_string() %}
+    varchar
+{% endmacro %}
+
+{% macro redshift__type_max_string() %}
+    varchar(max)
+{% endmacro %}
+
+{% macro postgres__type_max_string() %}
+    text
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation
- Add a type_string macro to generate a varchar type (Close #65)
- Add cross_db macro documentation (Close #67)

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)

