### PR TITLE
Add support for Databricks runtimes below 10.4 (Close #85)

### DIFF
--- a/macros/utils/cross_db/timestamp_functions.sql
+++ b/macros/utils/cross_db/timestamp_functions.sql
@@ -34,6 +34,11 @@
 {% endmacro %}
 
 
+{% macro databricks__timestamp_add(datepart, interval, tstamp) %}
+    timestampadd({{datepart}}, {{interval}}, {{tstamp}})
+{% endmacro %}
+
+
 {% macro cast_to_tstamp(tstamp_literal) -%}
   {% if tstamp_literal is none or tstamp_literal|lower in ['null',''] %}
     cast(null as {{dbt_utils.type_timestamp()}})


### PR DESCRIPTION
## Description & motivation
Add support for Databricks runtimes below 10.4

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
