### PR TITLE
Exclude specific entity versions from combine_column_version macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ The order of the matched columns is denoted by their ordinal position.
 
 As your schemas for such columns evolve, multiple versions of the same column will be created in your events table e.g. `custom_context_1_0_0`, `custom_context_1_0_1`. These columns contain nested fields i.e. are of a datatype `RECORD`. When modeling Snowplow data it can be useful to combine or coalesce each nested field across all versions of the column for a continuous view over time. This macro mitigates the need to update your coalesce statement each time a new version of the column is created.
 
-Fields can be selected using 3 methods:
+Fields can be selected using 4 methods:
 
 - Select all fields. Default.
 - Select by field name using the `required_fields` arg.
 - Select all fields at a given level/depth of nesting e.g. all 1st level fields. Uses the `nested_level` arg.
+- Select all fields, excluding specific versions using the `exclude_versions` arg.
 
 By default any returned fields will be assigned an alias matching the field name e.g. `coalesce(<col_v2>.product, <col_v1>.product) as product`. For heavily nested fields, the alias will be field's path with `.` replaced with `_` e.g. for a field `product.size.height` will have an alias `product_size_height`. A custom alias can be supplied with the `required_fields` arg (see below).
 
@@ -110,6 +111,7 @@ By default any returned fields will be assigned an alias matching the field name
 - `include_field_alias`: Default `True`. Determines whether to included the field alias in the final coalesced field e.g. `coalesce(...) as <field_alias>`. Useful when using the field as part of a join.
 - `array_index`: Default 0. If the column is of mode `REPEATED` i.e. an array, this determines the element to take. All Snowplow context columns are arrays, typically with only a single element.
 - `max_nested_level`: Default 15. Imposes a hard stop for recursions on heavily nested data.
+- `exclude_versions`: Optional. List of versions to be excluded from column coalescing. Versions should be provided as an array of strings in snake case (`['1_0_0']`)
 
 **Returns:**
 

--- a/macros/utils/bigquery/combine_column_versions/exclude_column_versions.sql
+++ b/macros/utils/bigquery/combine_column_versions/exclude_column_versions.sql
@@ -1,0 +1,12 @@
+{% macro exclude_column_versions(columns, exclude_versions) %}
+  {%- set filtered_columns_by_version = [] -%}  
+  {% for column in columns %}
+    {%- set col_version = column.name[-5:] -%}
+    {% if col_version not in exclude_versions %}
+      {% do filtered_columns_by_version.append(column) %}
+    {% endif %}
+  {% endfor %}
+
+  {{ return(filtered_columns_by_version) }}
+
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation

Add the capability to exclude unwanted versions from the `combine_column_version` macro. 

We've encountered a need for this as we have introduced breaking changes to entity versions that cause BigQuery compilation errors when coalescing. For example, a change in field type across versions. This change allows for the avoidance of this by dropping known problematic versions out of the coalesce. 

This change makes the assumption that the column's version is always provided as the last 5 characters at the end of the column name (`column_X_X_X`).

### Example of use ###

<img width="371" alt="Screenshot 2022-09-16 at 15 49 10" src="https://user-images.githubusercontent.com/43554151/190667578-b518ba04-ec90-43c4-a699-3b8256920d80.png">

To exclude version `1_0_0` from the coalescing: 

```sql
{%- set all_fields = snowplow_utils.combine_column_versions(
                                relation=ref('snowplow_web_base_events_this_run'),
                                column_prefix='product_v',
                                exclude_versions=['1_0_1'],
                                ) -%}

select
{% for field in all_fields %}
  {{field}} {%- if not loop.last %},{% endif %}
{% endfor %}

# Renders to:
select
  coalesce(product_1_0_2[safe_offset(0)].name, product_1_0_0[safe_offset(0)].name) as name,
  coalesce(product_1_0_2[safe_offset(0)].id, product_1_0_0[safe_offset(0)].id) as id,
  coalesce(product_1_0_2[safe_offset(0)].specs) as specs,
  coalesce(product_1_0_2[safe_offset(0)].specs.power_rating) as specs_power_rating,
  coalesce(product_1_0_2[safe_offset(0)].specs.volume) as specs_volume
```

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
