### PR TITLE
Feature/standardise macro inheritence

### DIFF
--- a/macros/utils/cross_db/timestamp_functions.sql
+++ b/macros/utils/cross_db/timestamp_functions.sql
@@ -67,13 +67,10 @@
     unix_seconds({{ tstamp }})
 {%- endmacro %}
 
-{%- macro databricks__to_unixtstamp(tstamp) -%}
+{%- macro spark__to_unixtstamp(tstamp) -%}
     unix_timestamp({{ tstamp }})
 {%- endmacro %}
 
-{%- macro spark__to_unixtstamp(tstamp) -%}
-    {{ return(snowplow_utils.databricks__to_unixtstamp(tstamp)) }}
-{%- endmacro %}
 
 {% macro current_timestamp_in_utc() -%}
   {{ return(adapter.dispatch('current_timestamp_in_utc', 'snowplow_utils')()) }}

--- a/macros/utils/get_schemas_by_pattern.sql
+++ b/macros/utils/get_schemas_by_pattern.sql
@@ -12,8 +12,8 @@
 
 {% endmacro %}
 
-{% macro databricks__get_schemas_by_pattern(schema_pattern) %}
-    {# databricks uses a regex on SHOW SCHEMAS and doesn't have an information schema in hive_metastore #}
+{% macro spark__get_schemas_by_pattern(schema_pattern) %}
+    {# databricks/spark uses a regex on SHOW SCHEMAS and doesn't have an information schema in hive_metastore #}
     {%- set schema_pattern= dbt.replace(schema_pattern, "%", "*") -%}
 
     {# Get all schemas with the target.schema prefix #}
@@ -27,7 +27,3 @@
     {{ return(schemas) }}
 
 {% endmacro %}
-
-{%- macro spark__get_schemas_by_pattern(schema_pattern) -%}
-    {{ return(snowplow_utils.databricks__get_schemas_by_pattern(schema_pattern)) }}
-{%- endmacro %}

--- a/macros/utils/log_message.sql
+++ b/macros/utils/log_message.sql
@@ -1,7 +1,3 @@
 {% macro log_message(message, is_printed=var('snowplow__has_log_enabled', true)) %}
-    {{ return(adapter.dispatch('log_message', 'snowplow_utils')(message, is_printed)) }}
-{% endmacro %}
-
-{% macro default__log_message(message, is_printed) %}
     {{ log(dbt_utils.pretty_log_format(message), info=is_printed) }}
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation
As part of style guide, removing erroneous spark/databricks calls where they are the same. Also don't bother to dispatch the log message as there wasn't any point? 

## Checklist
- [x] I have verified that these changes work locally
- [NA] I have updated the README.md (if applicable)
- [NA] I have added tests & descriptions to my models (and macros if applicable)
- [NA] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

