### PR TITLE
Predicate incremental materialization

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@ name: 'snowplow_utils'
 version: '0.13.2'
 config-version: 2
 
-require-dbt-version: [">=1.3.0", "<2.0.0"]
+require-dbt-version: [">=1.4.0", "<2.0.0"]
 
 profile: 'default'
 

--- a/macros/materializations/base_incremental/common/get_merge_sql.sql
+++ b/macros/materializations/base_incremental/common/get_merge_sql.sql
@@ -3,8 +3,8 @@
     {%- set predicate_override = "" -%}
     {%- set orig_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
 
-    {%- set optimise = config.get('snowplow_optimise') -%}
-    {% if optimise %}
+    {%- set optimize = config.get('snowplow_optimize') -%}
+    {% if optimize %}
         -- run some queries to dynamically determine the min + max of this 'upsert_date_key' in the new data
         {%- set date_column = config.require('upsert_date_key') -%}
         {%- set disable_upsert_lookback = config.get('disable_upsert_lookback') -%} {# We do this for late arriving data possibly e.g. shifting a session start earlier #}
@@ -48,8 +48,8 @@
     {# Set default predicates to pass on #}
     {%- set predicate_override = "" -%}
     {%- set orig_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
-    {%- set optimise = config.get('snowplow_optimise') -%}
-    {% if optimise %}
+    {%- set optimize = config.get('snowplow_optimize') -%}
+    {% if optimize %}
         -- run some queries to dynamically determine the min + max of this 'upsert_date_key' in the new data
         {%- set date_column = config.require('upsert_date_key') -%}
         {%- set disable_upsert_lookback = config.get('disable_upsert_lookback') -%}

--- a/macros/materializations/base_incremental/common/get_merge_sql.sql
+++ b/macros/materializations/base_incremental/common/get_merge_sql.sql
@@ -1,0 +1,88 @@
+{% macro default__get_merge_sql(target_tb, source, unique_key, dest_columns, incremental_predicates = none) -%}
+    {# Set default predicates to pass on #}
+    {%- set predicate_override = "" -%}
+    {%- set orig_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
+
+    {%- set optimise = config.get('snowplow_optimise') -%}
+    {% if optimise %}
+        -- run some queries to dynamically determine the min + max of this 'upsert_date_key' in the new data
+        {%- set date_column = config.require('upsert_date_key') -%}
+        {%- set disable_upsert_lookback = config.get('disable_upsert_lookback') -%} {# We do this for late arriving data possibly e.g. shifting a session start earlier #}
+        {% set get_limits_query %}
+            {% if disable_upsert_lookback %}
+                select
+                    min({{ date_column }}) as lower_limit,
+                    max({{ date_column }}) as upper_limit
+                from {{ source }}
+            {% else %}
+                select
+                    {{ dateadd('day', -var("snowplow__upsert_lookback_days", 30), 'min('~date_column~')') }} as lower_limit,
+                    max({{ date_column }}) as upper_limit
+                from {{ source }}
+            {% endif %}
+        {% endset %}
+
+        {% set limits = run_query(get_limits_query)[0] %}
+        {% set lower_limit, upper_limit = limits[0], limits[1] %}
+
+        -- use those calculated min + max values to limit 'target' scan, to only the days with new data
+        {% set predicate_override %}
+            DBT_INTERNAL_DEST.{{ date_column }} between '{{ lower_limit }}' and '{{ upper_limit }}'
+        {% endset %}
+    {% endif %}
+
+    {# Combine predicates with user provided ones #}
+    {% set predicates = [predicate_override] + orig_predicates if predicate_override else orig_predicates %}
+    -- standard merge from here
+    {% if target.type in ['databricks', 'spark'] -%}
+        {% set merge_sql = spark__get_merge_sql(target_tb, source, unique_key, dest_columns, predicates) %}
+    {% else %}
+        {% set merge_sql = dbt.default__get_merge_sql(target_tb, source, unique_key, dest_columns, predicates) %}
+    {% endif %}
+
+    {{ return(merge_sql) }}
+
+{% endmacro %}
+
+{% macro default__get_delete_insert_merge_sql(target_tb, source, unique_key, dest_columns, incremental_predicates) -%}
+    {# Set default predicates to pass on #}
+    {%- set predicate_override = "" -%}
+    {%- set orig_predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
+    {%- set optimise = config.get('snowplow_optimise') -%}
+    {% if optimise %}
+        -- run some queries to dynamically determine the min + max of this 'upsert_date_key' in the new data
+        {%- set date_column = config.require('upsert_date_key') -%}
+        {%- set disable_upsert_lookback = config.get('disable_upsert_lookback') -%}
+        {% set get_limits_query %}
+            {% if disable_upsert_lookback %}
+                select
+                    min({{ date_column }}) as lower_limit,
+                    max({{ date_column }}) as upper_limit
+                from {{ source }}
+            {% else %}
+                select
+                    {{ dateadd('day', -var("snowplow__upsert_lookback_days", 30), 'min('~date_column~')') }} as lower_limit,
+                    max({{ date_column }}) as upper_limit
+                from {{ source }}
+            {% endif %}
+        {% endset %}
+
+        {% set limits = run_query(get_limits_query)[0] %}
+        {% set lower_limit, upper_limit = limits[0], limits[1] %}
+        -- use those calculated min + max values to limit 'target' scan, to only the days with new data
+        {% set predicate_override %}
+            {{ date_column }} between '{{ lower_limit }}' and '{{ upper_limit }}'
+        {% endset %}
+    {% endif %}
+    {# Combine predicates with user provided ones #}
+    {% set predicates = [predicate_override] + orig_predicates if predicate_override else orig_predicates %}
+    -- standard merge from here
+    {% if target.type in ['databricks', 'spark'] -%}
+        {% set merge_sql = spark__get_delete_insert_merge_sql(target_tb, source, unique_key, dest_columns, predicates) %}
+    {% else %}
+        {% set merge_sql = dbt.default__get_delete_insert_merge_sql(target_tb, source, unique_key, dest_columns, predicates) %}
+    {% endif %}
+
+    {{ return(merge_sql) }}
+
+{% endmacro %}

--- a/macros/materializations/snowplow_incremental/common/snowplow_validate_get_incremental_strategy.sql
+++ b/macros/materializations/snowplow_incremental/common/snowplow_validate_get_incremental_strategy.sql
@@ -4,7 +4,12 @@
 
 
 {% macro default__snowplow_validate_get_incremental_strategy(config) %}
-  
+
+  {% if execute %}
+    {%- set error_message = "Warning: the `snowplow_incremental` materialization is deprecated and should be replaced with dbt's `incremental` materialization, setting `snowplow_optimize: true` in your model config, and setting the appropriate dispatch search order in your project. See https://docs.snowplow.io//docs/modeling-your-data/modeling-your-data-with-dbt/dbt-advanced-usage/dbt-incremental-logic-pre-release/ for more details. The `snowplow_incremental` materialization will be removed completely in a future version of the package." -%}
+    {%- do exceptions.warn(error_message) -%}
+  {% endif %}
+
   {# Find and validate the incremental strategy #}
   {%- set strategy = config.get("incremental_strategy", default="merge") -%}
 
@@ -27,7 +32,12 @@
 
 
 {% macro snowflake__snowplow_validate_get_incremental_strategy(config) %}
-  
+
+  {% if execute %}
+    {%- set error_message = "Warning: the `snowplow_incremental` materialization is deprecated and should be replaced with dbt's `incremental` materialization, setting `snowplow_optimize: true` in your model config, and setting the appropriate dispatch search order in your project. See https://docs.snowplow.io//docs/modeling-your-data/modeling-your-data-with-dbt/dbt-advanced-usage/dbt-incremental-logic-pre-release/ for more details. The `snowplow_incremental` materialization will be removed completely in a future version of the package." -%}
+    {%- do exceptions.warn(error_message) -%}
+  {% endif %}
+
   {# Find and validate the incremental strategy #}
   {%- set strategy = config.get("incremental_strategy", default="merge") -%}
 

--- a/macros/utils/cross_db/datatypes.sql
+++ b/macros/utils/cross_db/datatypes.sql
@@ -1,7 +1,12 @@
 {# string  -------------------------------------------------     #}
 
 {%- macro type_string(max_characters) -%}
-  {{ return(adapter.dispatch('type_string', 'snowplow_utils')(max_characters)) }}
+    {% if max_characters %}
+        {{ return(adapter.dispatch('type_string', 'snowplow_utils')(max_characters)) }}
+    {% else %}
+        {{ return(adapter.dispatch('type_max_string', 'snowplow_utils')()) }}
+    {% endif %}
+
 {%- endmacro -%}
 
 {% macro default__type_string(max_characters) %}
@@ -9,6 +14,10 @@
 {% endmacro %}
 
 {% macro bigquery__type_string(max_characters) %}
+    string
+{% endmacro %}
+
+{% macro spark__type_string(max_characters) %}
     string
 {% endmacro %}
 


### PR DESCRIPTION
## Description & motivation
### Problem you are trying to solve
The current materialization is complex and out-dated, missing key new features that the dbt incremental method offers such as the `on_schema_change` flag, and more recently the incremental predicates. To add these features and to continue to support the materialization across 4+ warehouses is a large amount of work when compared to the relatively small difference our materialization offers over the default, i.e. the date filter on upserts.

### How you solved it
Using the new incremental predicates we are able to generate the same date filter to be applied onto the merge statements, without having to copy the entire materialization. This requires an overwrite of the `dispatch` in the user's project yaml file.

### Decision points
1) The decision to overwrite the `default__get_merge_sql` and `default__get_delete_insert_merge_sql` macros (which is what requires the dispatch setting) was made due to a limitation in how predicates are compiled/rendered at compile time only, which means it is not possible to generate a dynamic predicate directly for use in the model config. See discussion [here](https://github.com/dbt-labs/dbt-core/issues/6658) for further details on this. If that feature request is closed, this could be further simplified in the future. Overall the additional step for the user was deemed reasonable compared to the effort to maintain our materialization, and will only impact users with high volumes of data if they were not to set it.
2) The overall performance of the methods was compared in a relatively small test, this will be a release candidate to allow users to alert us to any large slow down in their models using this method.
3) There are currently no specific tests for the new materialization, outside of testing it locally to make sure it works. These will be added as part of the main release/a later release candidate.
4) Because the dispatch overwrite now forces the use of dbt-utils over base dbt, I had to also edit the type_string macro. In general I think we may want to rename our macros in future to ensure 0 clashes with base dbt but for now this resolved issues I was having downstream.

### Other notes
- There is currently no link in the deprecation notice, this will be added once we build the docs for how to add this dispatch setting/update the page on our materialization in the docs, as part of the release. For now all those details will be added to the changelog and discourse post.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] Docs (https://github.com/snowplow/documentation/pull/327)