### PR TITLE
Release/snowplow utils/0.14.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+snowplow-utils 0.14.3 (2023-07-04)
+---------------------------------------
+## Summary
+This version adds the ability to specify which package is returning the run limits in the `print_run_limits` macro, and fixes an issue with using string agg in Databricks with many `null` values.
+
+## Features
+- Add ability to tag package in limits (Close #133)
+
+## Fixes
+- Fix issue with large volume of nulls in databricks string agg
+
+## Upgrading
+To upgrade bump the package version in your `packages.yml` file.
+
 snowplow-utils 0.14.2 (2023-04-19)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils'
-version: '0.14.2'
+version: '0.14.3'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils_integration_tests'
-version: '0.14.2'
+version: '0.14.3'
 config-version: 2
 
 profile: 'integration_tests'

--- a/macros/incremental_hooks/get_incremental_manifest_status.sql
+++ b/macros/incremental_hooks/get_incremental_manifest_status.sql
@@ -46,7 +46,7 @@
 {%- endmacro %}
 
 {# Prints the run limits for the run to the console #}
-{% macro print_run_limits(run_limits_relation) -%}
+{% macro print_run_limits(run_limits_relation, package= none) -%}
 
   {% set run_limits_query %}
     select lower_limit, upper_limit from {{ run_limits_relation }}
@@ -60,6 +60,9 @@
     {% set lower_limit = snowplow_utils.tstamp_to_str(results.columns[0].values()[0]) %}
     {% set upper_limit = snowplow_utils.tstamp_to_str(results.columns[1].values()[0]) %}
     {% set run_limits_message = "Snowplow: Processing data between " + lower_limit + " and " + upper_limit %}
+    {% if package %}
+        {% set run_limits_message = run_limits_message +  " (" + package + ")" %}
+    {% endif %}
 
     {% do snowplow_utils.log_message(run_limits_message) %}
 

--- a/macros/utils/cross_db/get_string_agg.sql
+++ b/macros/utils/cross_db/get_string_agg.sql
@@ -98,8 +98,8 @@
     {% if is_distinct %} array_distinct( {% endif %}
     transform(
       array_sort(
-        collect_list(
-          ARRAY({{column_prefix}}.{{base_column}}::string, {{order_by_column_prefix}}.{{order_by_column}}::string)), (left, right) ->
+        FILTER(collect_list(
+          ARRAY({{column_prefix}}.{{base_column}}::string, {{order_by_column_prefix}}.{{order_by_column}}::string)), x -> x[0] is not null), (left, right) ->
 
           {%- if sort_numeric -%}
             CASE WHEN cast(left[1] as numeric(38, 9)) {% if order_desc %} > {% else %} < {% endif %} cast(right[1] as numeric(38, 9)) THEN -1


### PR DESCRIPTION
## Description & motivation
This release does 2 things:
1) It adds the ability to add the package name that is calling the run limits to the message, which was a requested feature and will need porting into our other packages but this enables it.
2) It fixes a weird databricks bug that can happen when you try and array sort hundreds of nulls that leads to a java based error. I can't reliably reproduce it in the int tests without adding thousands of events so you'll have to take my word that it seems to consistently fix the issue by removing null-valued items from the sort first (these were removed by the array_join function later anyway so the result is the same). This should be more efficient and not cause the same issue.

I've done it in one big PR because it's was two tiny changes. None of these should be breaking so we can do a patch release which means that no other packages will need bumping. @emielver you should be able to easily rebase but I don't think it matters much.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)


## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md

