### PR TITLE
Fixes + check for dupes contexts in postgres/redshift

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -47,7 +47,7 @@ vars:
     snowplow__event_limits: 'snowplow_base_new_event_limits_actual'
     snowplow__incremental_manifest: 'snowplow_incremental_manifest_actual'
     snowplow__entities_or_sdes: null
-    snowplow__custom_entities_or_sdes: [{"name" : "contexts_com_snowplowanalytics_custom_entity_1_0_0", "prefix": "custom", "single_entity": true}]
+    snowplow__custom_entities_or_sdes: [{"schema" : "contexts_com_snowplowanalytics_custom_entity_1_0_0", "prefix": "custom", "single_entity": true}]
     snowplow__bigquery_custom_sql: 'cast(contexts_com_snowplowanalytics_custom_entity_1_0_0[safe_offset(0)].contents as STRING) as custom_contents'
     snowplow__databricks_custom_sql: 'contexts_com_snowplowanalytics_custom_entity_1_0_0[0].contents as custom_contents'
     snowplow__snowflake_custom_sql: 'contexts_com_snowplowanalytics_custom_entity_1_0_0[0].contents::TEXT as custom_contents'

--- a/macros/base/base_create_snowplow_events_this_run.sql
+++ b/macros/base/base_create_snowplow_events_this_run.sql
@@ -95,13 +95,13 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
     {% if entities_or_sdes %}
         {% set ent_sde_names = [] %}
         {% for ent_or_sde in entities_or_sdes %}
-            {% do ent_sde_names.append(ent_or_sde['name']) %}
-            {% if ent_or_sde['name'] in unique_session_identifiers.keys() %}
-                {% do exceptions.warn("Snowplow Warning: Context or SDE ( " ~ ent_or_sde['name'] ~ " ) used for session_identifier is being included, using alias and prefix from session_identifier ( " ~ unique_session_identifiers[ent_or_sde['name']] ~ " ).") %}
+            {% do ent_sde_names.append(ent_or_sde['schema']) %}
+            {% if ent_or_sde['schema'] in unique_session_identifiers.keys() %}
+                {% do exceptions.warn("Snowplow Warning: Context or SDE ( " ~ ent_or_sde['schema'] ~ " ) used for session_identifier is being included, using alias and prefix from session_identifier ( " ~ unique_session_identifiers[ent_or_sde['schema']] ~ " ).") %}
             {% endif %}
         {% endfor %}
         {% if ent_sde_names | unique | list | length != entities_or_sdes | length %}
-            {% do exceptions.raise_compiler_error("There are duplicate names in your provided `entities_or_sdes` list. Please correct this before proceeding.")%}
+            {% do exceptions.raise_compiler_error("There are duplicate schema names in your provided `entities_or_sdes` list. Please correct this before proceeding.")%}
         {% endif %}
     {% endif %}
 
@@ -126,10 +126,10 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
                 {%- set name = none -%}
                 {%- set prefix = none -%}
                 {%- set single_entity = true -%}
-                {%- if ent_or_sde['name'] -%}
-                    {%- set name = ent_or_sde['name'] -%}
+                {%- if ent_or_sde['schema'] -%}
+                    {%- set name = ent_or_sde['schema'] -%}
                 {%- else -%}
-                    {%- do exceptions.raise_compiler_error("Need to specify the name of your Entity or SDE using the {'name'} attribute in a key-value map.") -%}
+                    {%- do exceptions.raise_compiler_error("Need to specify the schema name of your Entity or SDE using the {'schema'} attribute in a key-value map.") -%}
                 {%- endif -%}
                 {%- if ent_or_sde['prefix'] -%}
                     {%- set prefix = ent_or_sde['prefix'] -%}
@@ -139,7 +139,7 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
                 {%- if ent_or_sde['single_entity'] and ent_or_sde['single_entity'] is boolean -%}
                     {%- set single_entity = ent_or_sde['single_entity'] -%}
                 {%- endif %}
-                {% if ent_or_sde['name'] not in unique_session_identifiers.keys() %} {# Exclude any that we have already made above #}
+                {% if ent_or_sde['schema'] not in unique_session_identifiers.keys() %} {# Exclude any that we have already made above #}
                     {{ snowplow_utils.get_sde_or_context(snowplow_events_schema, name, lower_limit, upper_limit, prefix, single_entity) }},
                 {% endif %}
             {% endfor -%}
@@ -207,10 +207,10 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
                 {%- set prefix = none -%}
                 {%- set single_entity = true -%}
                 {%- set alias = none -%}
-                {%- if ent_or_sde['name'] -%}
-                    {%- set name = ent_or_sde['name'] -%}
+                {%- if ent_or_sde['schema'] -%}
+                    {%- set name = ent_or_sde['schema'] -%}
                 {%- else -%}
-                    {%- do exceptions.raise_compiler_error("Need to specify the name of your Entity or SDE using the {'name'} attribute in a key-value map.") -%}
+                    {%- do exceptions.raise_compiler_error("Need to specify the schema name of your Entity or SDE using the {'schema'} attribute in a key-value map.") -%}
                 {%- endif -%}
                 {%- if ent_or_sde['prefix'] and name not in unique_session_identifiers.keys() -%}
                     {%- set prefix = ent_or_sde['prefix'] -%}

--- a/macros/base/base_create_snowplow_events_this_run.sql
+++ b/macros/base/base_create_snowplow_events_this_run.sql
@@ -86,7 +86,9 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
                 {% do unique_session_identifiers.update({identifier['schema']: identifier}) %}
             {%- endif -%}
             {% if identifier['schema'] in unique_session_identifiers.keys() %}
-                {% do exceptions.warn("Snowplow Warning: Duplicate context ( " ~ identifier['schema'] ~" ) detected for session identifiers, using first alias and prefix provided ( " ~ unique_session_identifiers[identifier['schema']] ~ " ) in base events this run.") %}
+                {% if identifier['alias'] != unique_session_identifiers[identifier['schema']]['alias'] or identifier['prefix'] != unique_session_identifiers[identifier['schema']]['prefix']  %}
+                    {% do exceptions.warn("Snowplow Warning: Duplicate context ( " ~ identifier['schema'] ~" ) detected for session identifiers, using first alias and prefix provided ( " ~ unique_session_identifiers[identifier['schema']] ~ " ) in base events this run.") %}
+                {% endif %}
             {% endif %}
         {% endfor %}
     {% endif %}
@@ -97,7 +99,9 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
         {% for ent_or_sde in entities_or_sdes %}
             {% do ent_sde_names.append(ent_or_sde['schema']) %}
             {% if ent_or_sde['schema'] in unique_session_identifiers.keys() %}
-                {% do exceptions.warn("Snowplow Warning: Context or SDE ( " ~ ent_or_sde['schema'] ~ " ) used for session_identifier is being included, using alias and prefix from session_identifier ( " ~ unique_session_identifiers[ent_or_sde['schema']] ~ " ).") %}
+                {% if ent_or_sde['alias'] != unique_session_identifiers[ent_or_sde['schema']]['alias'] or ent_or_sde['prefix'] != unique_session_identifiers[ent_or_sde['schema']]['prefix']  %}
+                    {% do exceptions.warn("Snowplow Warning: Context or SDE ( " ~ ent_or_sde['schema'] ~ " ) used for session_identifier is being included, using alias and prefix from session_identifier ( " ~ unique_session_identifiers[ent_or_sde['schema']] ~ " ).") %}
+                {% endif %}
             {% endif %}
         {% endfor %}
         {% if ent_sde_names | unique | list | length != entities_or_sdes | length %}


### PR DESCRIPTION
## Description & motivation
@agnessnowplow Raised an issue around when the session/user identifiers have the same context it fails on PG/RS (due to duplicate CTEs with the same name). This is actually a wider issue, it would fail with the same context used multiple times in one of the identifiers, and also if you use the context as an identifier then add it in the `entity_or_sde` as well. Giving each CTE a custom name felt complicated, so I have instead made the logic directly on the base macros.

Basically, I have got a distinct list of contexts that need CTEing and joining, and where there are duplicates it uses the alias and prefix of the _FIRST_ instance, but the _FIELD_ of the actual record (please double check I haven't misses this anywhere). I do not raise a warning in the manifest because they should never need to access the inner workings of this code so we can just manage it for them.

I also made a few other tweaks while I was here.

We should probably add some tests for this, but that felt like a large task that we may not have time to do before release

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
