### PR TITLE
Feature/add index to unnest and array size macro

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -2,9 +2,6 @@ name: pr_tests
 
 on:
   pull_request:
-    branches:
-      - main
-      - 'release/**'
 
 concurrency: dbt_integration_tests
 

--- a/integration_tests/models/utils/cross_db/cross_db.yml
+++ b/integration_tests/models/utils/cross_db/cross_db.yml
@@ -19,3 +19,7 @@ models:
           compare_model: ref('expected_get_field_bq')
           config:
             +enabled: "{{  target.type in ['bigquery'] | as_bool() }}"
+  - name: test_indexed_unnest
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_indexed_unnest')

--- a/integration_tests/models/utils/cross_db/data_indexed_unnest.sql
+++ b/integration_tests/models/utils/cross_db/data_indexed_unnest.sql
@@ -1,0 +1,27 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Community License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+#}
+
+{# Everything says int but I've made some of them decimals to test that as well #}
+
+{{
+  config(
+    materialized = 'table',
+    )
+}}
+
+with data as (
+
+  select
+    test_type,
+    {{ snowplow_utils.get_split_to_array('result', 'g', ';') }} as test_array
+    
+  from {{ ref('expected_get_string_agg')}} g
+  
+  where test_type in ('string_def_colon_false_false', 'string_string_colon_false_true', 'int_def_colon_false_true')
+)
+
+select * from data

--- a/integration_tests/models/utils/cross_db/expected_indexed_unnest.sql
+++ b/integration_tests/models/utils/cross_db/expected_indexed_unnest.sql
@@ -1,0 +1,109 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Community License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+#}
+
+  select
+  'string_def_colon_false_false' as test_type,
+  'a' as element,
+  0 as source_index
+  
+  union all
+  
+  select
+  'string_def_colon_false_false' as test_type,
+  'b' as element,
+  1 as source_index
+  
+  union all
+  
+  select
+  'string_def_colon_false_false' as test_type,
+  'c' as element,
+  2 as source_index
+  
+  union all
+  
+  select
+  'string_def_colon_false_false' as test_type,
+  'c' as element,
+  3 as source_index
+  
+  union all
+  
+  select
+  'string_def_colon_false_false' as test_type,
+  'd' as element,
+  4 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'c' as element,
+  0 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'd' as element,
+  1 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'b' as element,
+  2 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'c' as element,
+  3 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'a' as element,
+  4 as source_index
+  
+  union all 
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '4' as element,
+  0 as source_index
+  
+  union all
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '3' as element,
+  1 as source_index
+  
+  union all
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '3' as element,
+  2 as source_index
+  
+  union all
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '2' as element,
+  3 as source_index
+  
+  union all
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '1' as element,
+  4 as source_index

--- a/integration_tests/models/utils/cross_db/test_indexed_unnest.sql
+++ b/integration_tests/models/utils/cross_db/test_indexed_unnest.sql
@@ -1,0 +1,15 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Community License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+#}
+
+
+with data as (
+  
+  select * from {{ ref('data_indexed_unnest')}}
+)
+
+{{ snowplow_utils.unnest('test_type', 'test_array', 'element', 'data', with_index=true) }}
+

--- a/macros/utils/cross_db/get_array_size.sql
+++ b/macros/utils/cross_db/get_array_size.sql
@@ -1,0 +1,30 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Community License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+#}
+
+{#
+    Takes care of harmonising cross-db functions that create a string out of an array.
+#}
+
+{%- macro get_array_size(array_column) -%}
+    {{ return(adapter.dispatch('get_array_size', 'snowplow_utils')(array_column)) }}
+{%- endmacro -%}
+
+{% macro default__get_array_size(array_column) %}
+    array_size({{array_column}})
+{% endmacro %}
+
+{% macro bigquery__get_array_size(array_column) %}
+  array_length({{array_column}})
+{% endmacro %}
+
+{% macro postgres__get_array_size(array_column) %}
+    array_length({{array_column}})
+{% endmacro %}
+
+{% macro redshift__get_array_size(array_column) %}
+  get_array_length({{array_column}})
+{% endmacro %}

--- a/macros/utils/cross_db/unnest.sql
+++ b/macros/utils/cross_db/unnest.sql
@@ -9,31 +9,36 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
     Takes care of harmonising cross-db unnesting.
 #}
 
-{%- macro unnest(id_column, unnest_column, field_alias, source_table) -%}
-    {{ return(adapter.dispatch('unnest', 'snowplow_utils')(id_column, unnest_column, field_alias, source_table)) }}
+{%- macro unnest(id_column, unnest_column, field_alias, source_table, with_index=false) -%}
+    {{ return(adapter.dispatch('unnest', 'snowplow_utils')(id_column, unnest_column, field_alias, source_table, with_index)) }}
 {%- endmacro -%}
 
-{% macro default__unnest(id_column, unnest_column, field_alias, source_table) %}
-    select {{ id_column }}, explode({{ unnest_column }}) as {{ field_alias }}
-    from {{ source_table }}
+{% macro default__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
+    {% if with_index %}
+        select {{ id_column }}, posexplode({{ unnest_column }}) as (source_index, {{ field_alias }})
+    {% else %}
+        select {{ id_column }}, explode({{ unnest_column }}) as {{ field_alias }}
+    {% endif %}
+        from {{ source_table }}
 {% endmacro %}
 
-{% macro bigquery__unnest(id_column, unnest_column, field_alias, source_table) %}
-    select {{ id_column }}, r as {{ field_alias }}
-    from {{ source_table }} t, unnest(t.{{ unnest_column }}) r
+{% macro bigquery__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
+    select {{ id_column }}, r as {{ field_alias }} {% if with_index %}, source_index {% endif %}
+    from {{ source_table }} t, unnest(t.{{ unnest_column }}) r {% if with_index %} WITH OFFSET AS source_index {% endif %}
 {% endmacro %}
 
-{% macro snowflake__unnest(id_column, unnest_column, field_alias, source_table) %}
+{% macro snowflake__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
     select t.{{ id_column }}, replace(r.value, '"', '') as {{ field_alias }}
+    {% if with_index %}, r.index as source_index {% endif %}
     from {{ source_table }} t, table(flatten(t.{{ unnest_column }})) r
 {% endmacro %}
 
-{% macro postgres__unnest(id_column, unnest_column, field_alias, source_table) %}
+{% macro postgres__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
     select {{ id_column }}, trim(unnest({{ unnest_column }})) as {{ field_alias }}
     from {{ source_table }}
 {% endmacro %}
 
-{% macro redshift__unnest(id_column, unnest_column, field_alias, source_table) %}
-    select {{ id_column }}, {{ field_alias }}
-    from {{ source_table }} p, p.{{ unnest_column }} as {{ field_alias }}
+{% macro redshift__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
+    select {{ id_column }}, {{ field_alias }} {% if with_index %} , index as source_index
+    from {{ source_table }} p, p.{{ unnest_column }} as {{ field_alias }} at index {% endif %} 
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation
This pull request is to support the new marketing attribution package. It adds a new cross-db macro to get the array size and also adds the optional functionality to retrieve the index number (starting from 0) for the unnest() macro. This latter currently only supports Snowflake the rest needs testing/to be added hence it's currently draft pull request.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)


