### PR TITLE
Release/snowplow utils/0.16.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @emielver
+*       @snowplow/com-snowplowanalytics-engineering-datavalue-integrations

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -2,9 +2,6 @@ name: pr_tests
 
 on:
   pull_request:
-    branches:
-      - main
-      - 'release/**'
 
 concurrency: dbt_integration_tests
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,22 @@
+snowplow-utils 0.16.0 (2024-01-26)
+---------------------------------------
+## Summary
+This release contains a new array size macro as well as the optional ability for the unnest macros to also surface the index of the original array element for preserving the order. It also contains some fixes for redshift. Please note that from this version onwards this package is under the SPAL license.
+
+# Features
+- Add get_array_size macro
+- Add optional index to unnest
+
+## Fixes
+- Fix existing tests for redshift
+- Fix issue with multiple end hooks failing (Close #152)
+
+## Under the hood
+- Update license to SPAL
+
+## Upgrading
+To upgrade, bump the package version in your `packages.yml` file.
+
 snowplow-utils 0.15.2 (2023-10-13)
 ---------------------------------------
 ## Summary

--- a/LICENSE
+++ b/LICENSE
@@ -1,51 +1,57 @@
-# Snowplow Community License Agreement
+# Snowplow Personal & Academic License Agreement
 
-_Version 1.0, January 2023_
+_Version 1.0, September 2023_
 
-This Snowplow Community License Agreement, Version 1.0 (the “Agreement”) sets forth the terms on which Snowplow Analytics, Ltd. (“Snowplow”) makes available certain software made available by Snowplow under this Agreement (the “Software”). BY INSTALLING, DOWNLOADING, ACCESSING, OR USING ANY OF THE SOFTWARE, YOU AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE TO SUCH TERMS AND CONDITIONS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY. “Licensee” means you, an individual, or the entity on whose behalf you are receiving the Software.
+## Acceptance
 
-## LICENSE GRANT AND CONDITIONS
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
 
-**1.1 License.** Subject to the terms and conditions of this Agreement, Snowplow hereby grants to Licensee a non-exclusive, royalty-free, worldwide, non-transferable, non-sublicenseable license during the term of this Agreement to: (a) use the Software; (b) prepare modifications and derivative works of the Software; and (c) reproduce copies of the Software (the “License”). No right to distribute or make available the Software is granted under this License. Licensee is not granted the right to, and Licensee shall not, exercise the License for an Excluded Purpose. For purposes of this Agreement, “Excluded Purpose” means making available any on-premises or distributed software product, software-as-a-service, platform-as-a-service, infrastructure-as-a-service, or other similar online service, that competes with any products or services that Snowplow or any of its affiliates provides using the Software.
+## Copyright License
 
-**1.2 Conditions.** In consideration of the License, Licensee’s distribution of the Software is subject to the following conditions:
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it, but only for any non-commercial purpose.
 
-* **a.** Licensee must cause any Software modified by Licensee to carry prominent notices stating that Licensee modified the Software.
+Non-commercial purposes include only:
 
-* **b.** On each Software copy, Licensee shall reproduce and not remove or alter all Snowplow or third party copyright or other proprietary notices contained in the Software, and Licensee must include the notice below on each copy.
+* Personal use for research, experiment, personal study, or hobby projects, without any anticipated commercial application.
+* Use for teaching purposes by lecturers of a school or university.
+* Use to evaluate the sufficiency of the software for the commercial needs of you or your company.
 
-  ```
-  This software is made available by Snowplow Analytics, Ltd.,
-  under the terms of the Snowplow Community License Agreement, Version 1.0
-  located at https://docs.snowplow.io/community-license-1.0
-  BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF THE SOFTWARE,
-  YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
-  ```
+## Notices
 
-**1.3 Licensee Modifications.** Licensee may add its own copyright notices to modifications made by Licensee.
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above.
 
-**1.4 No Sublicensing.** The License does not include the right to sublicense the Software, however, each recipient to which Licensee provides the Software may exercise the Licenses so long as such recipient agrees to the terms and conditions of this Agreement.
+## Patent License
 
-## TERM AND TERMINATION
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software for a non-commercial purpose.
 
-This Agreement will continue unless and until earlier terminated as set forth herein. If Licensee breaches any of its conditions or obligations under this Agreement, this Agreement will terminate automatically and the License will terminate automatically and permanently.
+## Fair Use
 
-## INTELLECTUAL PROPERTY
+You may have "fair use" rights for the software under the law. These terms do not limit them.
 
-As between the parties, Snowplow will retain all right, title, and interest in the Software, and all intellectual property rights therein. Snowplow hereby reserves all rights not expressly granted to Licensee in this Agreement. Snowplow hereby reserves all rights in its trademarks and service marks, and no licenses therein are granted in this Agreement.
+## No Other Rights
 
-## DISCLAIMER
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
 
-SNOWPLOW HEREBY DISCLAIMS ANY AND ALL WARRANTIES AND CONDITIONS, EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, WITH RESPECT TO THE SOFTWARE.
+## Patent Defense
 
-## LIMITATION OF LIABILITY
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
 
-SNOWPLOW WILL NOT BE LIABLE FOR ANY DAMAGES OF ANY KIND, INCLUDING BUT NOT LIMITED TO, LOST PROFITS OR ANY CONSEQUENTIAL, SPECIAL, INCIDENTAL, INDIRECT, OR DIRECT DAMAGES, HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ARISING OUT OF THIS AGREEMENT. THE FOREGOING SHALL APPLY TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+## Violations
 
-## GENERAL
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice. Otherwise, all your licenses end immediately.
 
-**6.1 Governing Law.** This Agreement will be governed by and interpreted in accordance with the laws of the state of Delaware, without reference to its conflict of laws principles. If Licensee is located within the United States, all disputes arising out of this Agreement are subject to the exclusive jurisdiction of courts located in Delaware, USA. If Licensee is located outside of the United States, any dispute, controversy or claim arising out of or relating to this Agreement will be referred to and finally determined by arbitration in accordance with the JAMS International Arbitration Rules. The tribunal will consist of one arbitrator. The place of arbitration will be in the State of Delaware, USA. The language to be used in the arbitral proceedings will be English. Judgment upon the award rendered by the arbitrator may be entered in any court having jurisdiction thereof.
+## No Liability
 
-**6.2. Assignment.** Licensee is not authorized to assign its rights under this Agreement to any third party. Snowplow may freely assign its rights under this Agreement to any third party.
+**As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.**
 
-**6.3. Other.** This Agreement is the entire agreement between the parties regarding the subject matter hereof. No amendment or modification of this Agreement will be valid or binding upon the parties unless made in writing and signed by the duly authorized representatives of both parties. In the event that any provision, including without limitation any condition, of this Agreement is held to be unenforceable, this Agreement and all licenses and rights granted hereunder will immediately terminate. Waiver by Snowplow of a breach of any provision of this Agreement or the failure by Snowplow to exercise any right hereunder will not be construed as a waiver of any subsequent breach of that right or as a waiver of any other right.
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -863,11 +863,10 @@ If you find a bug, please report an issue on GitHub.
 
 The snowplow-utils package is Copyright 2021-present Snowplow Analytics Ltd.
 
-Licensed under the [Snowplow Community License][license] (the "License");
-you may not use this software except in compliance with the License.
+This distribution is all licensed under the [Snowplow Personal and Academic License][license] . (If you are uncertain how it applies to your use case, check our answers to [frequently asked questions](https://docs.snowplow.io/docs/contributing/community-license-faq/).)
 
-[license]: https://docs.snowplow.io/community-license-1.0/
-[license-image]: http://img.shields.io/badge/license-Snowplow--Community--1-blue.svg?style=flat
+[license]: https://docs.snowplow.io/personal-and-academic-license-1.0/
+[license-image]: http://img.shields.io/badge/license-Snowplow--Personal--and--Academic--1-blue.svg?style=flat
 [tracker-classificiation]: https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/tracker-maintenance-classification/
 [early-release]: https://img.shields.io/static/v1?style=flat&label=Snowplow&message=Early%20Release&color=014477&labelColor=9ba0aa&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAeFBMVEVMaXGXANeYANeXANZbAJmXANeUANSQAM+XANeMAMpaAJhZAJeZANiXANaXANaOAM2WANVnAKWXANZ9ALtmAKVaAJmXANZaAJlXAJZdAJxaAJlZAJdbAJlbAJmQAM+UANKZANhhAJ+EAL+BAL9oAKZnAKVjAKF1ALNBd8J1AAAAKHRSTlMAa1hWXyteBTQJIEwRgUh2JjJon21wcBgNfmc+JlOBQjwezWF2l5dXzkW3/wAAAHpJREFUeNokhQOCA1EAxTL85hi7dXv/E5YPCYBq5DeN4pcqV1XbtW/xTVMIMAZE0cBHEaZhBmIQwCFofeprPUHqjmD/+7peztd62dWQRkvrQayXkn01f/gWp2CrxfjY7rcZ5V7DEMDQgmEozFpZqLUYDsNwOqbnMLwPAJEwCopZxKttAAAAAElFTkSuQmCC
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils'
-version: '0.15.2'
+version: '0.16.0'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -29,7 +29,8 @@ on-run-start:
 on-run-end:
   - "{{ test_get_successful_models(enabled=var('enabled_test_get_successful_models', false)) }}"
   - "{{ snowplow_utils.snowplow_incremental_post_hook('snowplow', var('snowplow__incremental_manifest'), 'snowplow_base_events_this_run_actual', var('snowplow__session_timestamp')) }}"
-
+  - "{{ snowplow_utils.snowplow_incremental_post_hook('snowplow', var('snowplow__incremental_manifest'), 'snowplow_base_events_this_run_actual', var('snowplow__session_timestamp')) }}"
+  
 vars:
   snowplow_utils_integration_tests:
     # Disables compiler errors during testing. Returns error message string instead, which we can test against.
@@ -89,6 +90,8 @@ models:
           +enabled: "{{ target.type in ['bigquery'] | as_bool() }}"
         expected_get_field_bq:
           +enabled: "{{ target.type in ['bigquery'] | as_bool() }}"
+        data_get_string_agg_grp:
+          +materialized: table
 
     base:
       +bind: false
@@ -199,121 +202,121 @@ seeds:
           +enabled:  "{{ target.type in ['postgres', 'redshift'] | as_bool() }}"
           +column_types:
             root_tstamp: timestamp
-            root_id: varchar
-            session_id: varchar
-            schema_name: varchar
+            root_id: character varying
+            session_id: character varying
+            schema_name: character varying
         contexts_com_snowplowanalytics_session_identifier_2_0_0:
           +enabled:  "{{ target.type in ['postgres', 'redshift'] | as_bool() }}"
           +column_types:
             root_tstamp: timestamp
-            root_id: varchar
-            session_identifier: varchar
-            schema_name: varchar
+            root_id: character varying
+            session_identifier: character varying
+            schema_name: character varying
         contexts_com_snowplowanalytics_user_identifier_1_0_0:
           +enabled:  "{{ target.type in ['postgres', 'redshift'] | as_bool() }}"
           +column_types:
             root_tstamp: timestamp
-            root_id: varchar
-            user_id: varchar
-            schema_name: varchar
+            root_id: character varying
+            user_id: character varying
+            schema_name: character varying
         contexts_com_snowplowanalytics_user_identifier_2_0_0:
           +enabled:  "{{ target.type in ['postgres', 'redshift'] | as_bool() }}"
           +column_types:
             root_tstamp: timestamp
-            root_id: varchar
-            user_id: varchar
-            schema_name: varchar
+            root_id: character varying
+            user_id: character varying
+            schema_name: character varying
         contexts_com_snowplowanalytics_custom_entity_1_0_0:
           +enabled:  "{{ target.type in ['postgres', 'redshift'] | as_bool() }}"
           +column_types:
             root_tstamp: timestamp
-            root_id: varchar
-            contents: varchar
-            schema_name: varchar
+            root_id: character varying
+            contents: character varying
+            schema_name: character varying
         snowplow_events:
           +column_types:
-            app_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            platform: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            app_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            platform: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             etl_tstamp: timestamp
             collector_tstamp: timestamp
             dvce_created_tstamp: timestamp
-            event: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            event: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             txn_id: integer
-            name_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_collector: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_etl: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_ipaddress: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            name_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_collector: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_etl: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_ipaddress: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             domain_sessionidx: integer
-            network_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_region: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_zipcode: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            network_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_region: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_zipcode: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             geo_latitude: float
             geo_longitude: float
-            geo_region_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_isp: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_organization: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_domain: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_netspeed: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_url: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_title: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_referrer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            geo_region_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_isp: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_organization: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_domain: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_netspeed: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_url: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_title: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_referrer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             page_urlport: integer
-            page_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            page_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             refr_urlport: integer
-            refr_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_content: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_campaign: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_action: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_label: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_property: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            refr_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_content: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_campaign: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_action: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_label: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_property: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             se_value: float
-            tr_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_affiliation: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_affiliation: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             tr_total: float
             tr_tax: float
             tr_shipping: float
-            tr_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_state: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_sku: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_state: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_sku: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             ti_price: float
             ti_quantity: integer
             pp_xoffset_min: integer
             pp_xoffset_max: integer
             pp_yoffset_min: integer
             pp_yoffset_max: integer
-            useragent: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_renderengine: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_lang: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            useragent: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_renderengine: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_lang: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             br_features_pdf: boolean
             br_features_flash: boolean
             br_features_java: boolean
@@ -324,136 +327,136 @@ seeds:
             br_features_gears: boolean
             br_features_silverlight: boolean
             br_cookies: boolean
-            br_colordepth: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            br_colordepth: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             br_viewwidth: integer
             br_viewheight: integer
-            os_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_manufacturer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            dvce_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            os_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_manufacturer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            dvce_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             dvce_ismobile: boolean
             dvce_screenwidth: integer
             dvce_screenheight: integer
-            doc_charset: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            doc_charset: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             doc_width: integer
             doc_height: integer
-            tr_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             tr_total_base: float
             tr_tax_base: float
             tr_shipping_base: float
-            ti_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            ti_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             ti_price_base: float
-            base_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_clickid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_network: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            etl_tags: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            base_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_clickid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_network: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            etl_tags: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             dvce_sent_tstamp: timestamp
-            refr_domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            refr_domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             refr_dvce_tstamp: timestamp
-            domain_sessionid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            domain_sessionid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             derived_tstamp: timestamp
-            event_vendor: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_format: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            event_vendor: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_format: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             true_tstamp: timestamp
             load_tstamp: timestamp
-            contexts_com_snowplowanalytics_snowplow_web_page_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            unstruct_event_com_snowplowanalytics_snowplow_consent_preferences_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            unstruct_event_com_snowplowanalytics_snowplow_cmp_visible_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_com_iab_snowplow_spiders_and_robots_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_com_snowplowanalytics_snowplow_ua_parser_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_nl_basjes_yauaa_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            custom_contents: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            contexts_com_snowplowanalytics_snowplow_web_page_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            unstruct_event_com_snowplowanalytics_snowplow_consent_preferences_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            unstruct_event_com_snowplowanalytics_snowplow_cmp_visible_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_com_iab_snowplow_spiders_and_robots_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_com_snowplowanalytics_snowplow_ua_parser_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_nl_basjes_yauaa_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            custom_contents: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
       expected:
         snowplow_base_events_this_run_expected:
           +column_types:
-            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            app_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            platform: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            app_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            platform: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             etl_tstamp: timestamp
             collector_tstamp: timestamp
             dvce_created_tstamp: timestamp
-            event: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            event: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             txn_id: integer
-            name_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_collector: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_etl: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_ipaddress: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            name_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_collector: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_etl: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_ipaddress: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             domain_sessionidx: integer
-            network_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_region: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_zipcode: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            network_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_region: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_zipcode: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             geo_latitude: float
             geo_longitude: float
-            geo_region_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_isp: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_organization: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_domain: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_netspeed: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_url: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_title: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_referrer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            geo_region_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_isp: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_organization: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_domain: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_netspeed: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_url: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_title: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_referrer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             page_urlport: integer
-            page_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            page_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             refr_urlport: integer
-            refr_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_content: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_campaign: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_action: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_label: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_property: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            refr_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_content: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_campaign: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_action: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_label: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_property: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             se_value: float
-            tr_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_affiliation: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_affiliation: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             tr_total: float
             tr_tax: float
             tr_shipping: float
-            tr_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_state: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_sku: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_state: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_sku: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             ti_price: float
             ti_quantity: integer
             pp_xoffset_min: integer
             pp_xoffset_max: integer
             pp_yoffset_min: integer
             pp_yoffset_max: integer
-            useragent: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_renderengine: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_lang: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            useragent: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_renderengine: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_lang: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             br_features_pdf: boolean
             br_features_flash: boolean
             br_features_java: boolean
@@ -464,145 +467,145 @@ seeds:
             br_features_gears: boolean
             br_features_silverlight: boolean
             br_cookies: boolean
-            br_colordepth: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            br_colordepth: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             br_viewwidth: integer
             br_viewheight: integer
-            os_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_manufacturer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            dvce_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            os_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_manufacturer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            dvce_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             dvce_ismobile: boolean
             dvce_screenwidth: integer
             dvce_screenheight: integer
-            doc_charset: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            doc_charset: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             doc_width: integer
             doc_height: integer
-            tr_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             tr_total_base: float
             tr_tax_base: float
             tr_shipping_base: float
-            ti_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            ti_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             ti_price_base: float
-            base_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_clickid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_network: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            etl_tags: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            base_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_clickid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_network: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            etl_tags: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             dvce_sent_tstamp: timestamp
-            refr_domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            refr_domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             refr_dvce_tstamp: timestamp
-            domain_sessionid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            domain_sessionid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             derived_tstamp: timestamp
-            event_vendor: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_format: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            event_vendor: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_format: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             true_tstamp: timestamp
             load_tstamp: timestamp
-            contexts_com_snowplowanalytics_snowplow_web_page_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            unstruct_event_com_snowplowanalytics_snowplow_consent_preferences_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            unstruct_event_com_snowplowanalytics_snowplow_cmp_visible_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_com_iab_snowplow_spiders_and_robots_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_com_snowplowanalytics_snowplow_ua_parser_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_nl_basjes_yauaa_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            custom_contents: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            contexts_com_snowplowanalytics_snowplow_web_page_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            unstruct_event_com_snowplowanalytics_snowplow_consent_preferences_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            unstruct_event_com_snowplowanalytics_snowplow_cmp_visible_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_com_iab_snowplow_spiders_and_robots_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_com_snowplowanalytics_snowplow_ua_parser_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_nl_basjes_yauaa_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            custom_contents: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
         snowplow_base_quarantined_sessions_expected:
           +column_types:
-            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
         snowplow_base_sessions_this_run_expected:
           +column_types:
-            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             start_tstamp: timestamp
             end_tstamp: timestamp
         snowplow_base_events_this_run_expected_custom:
           +column_types:
-            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            app_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            platform: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            app_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            platform: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             etl_tstamp: timestamp
             collector_tstamp: timestamp
             dvce_created_tstamp: timestamp
-            event: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            event: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             txn_id: integer
-            name_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_collector: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_etl: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_ipaddress: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            name_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_collector: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_etl: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_ipaddress: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             domain_sessionidx: integer
-            network_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_region: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_zipcode: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            network_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_region: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_zipcode: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             geo_latitude: float
             geo_longitude: float
-            geo_region_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_isp: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_organization: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_domain: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_netspeed: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_url: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_title: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_referrer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            geo_region_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_isp: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_organization: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_domain: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_netspeed: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_url: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_title: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_referrer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             page_urlport: integer
-            page_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            page_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             refr_urlport: integer
-            refr_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_content: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_campaign: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_action: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_label: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_property: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            refr_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_content: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_campaign: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_action: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_label: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_property: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             se_value: float
-            tr_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_affiliation: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_affiliation: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             tr_total: float
             tr_tax: float
             tr_shipping: float
-            tr_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_state: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_sku: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_state: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_sku: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             ti_price: float
             ti_quantity: integer
             pp_xoffset_min: integer
             pp_xoffset_max: integer
             pp_yoffset_min: integer
             pp_yoffset_max: integer
-            useragent: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_renderengine: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_lang: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            useragent: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_renderengine: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_lang: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             br_features_pdf: boolean
             br_features_flash: boolean
             br_features_java: boolean
@@ -613,145 +616,145 @@ seeds:
             br_features_gears: boolean
             br_features_silverlight: boolean
             br_cookies: boolean
-            br_colordepth: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            br_colordepth: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             br_viewwidth: integer
             br_viewheight: integer
-            os_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_manufacturer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            dvce_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            os_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_manufacturer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            dvce_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             dvce_ismobile: boolean
             dvce_screenwidth: integer
             dvce_screenheight: integer
-            doc_charset: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            doc_charset: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             doc_width: integer
             doc_height: integer
-            tr_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             tr_total_base: float
             tr_tax_base: float
             tr_shipping_base: float
-            ti_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            ti_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             ti_price_base: float
-            base_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_clickid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_network: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            etl_tags: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            base_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_clickid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_network: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            etl_tags: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             dvce_sent_tstamp: timestamp
-            refr_domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            refr_domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             refr_dvce_tstamp: timestamp
-            domain_sessionid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            domain_sessionid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             derived_tstamp: timestamp
-            event_vendor: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_format: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            event_vendor: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_format: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             true_tstamp: timestamp
             load_tstamp: timestamp
-            contexts_com_snowplowanalytics_snowplow_web_page_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            unstruct_event_com_snowplowanalytics_snowplow_consent_preferences_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            unstruct_event_com_snowplowanalytics_snowplow_cmp_visible_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_com_iab_snowplow_spiders_and_robots_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_com_snowplowanalytics_snowplow_ua_parser_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_nl_basjes_yauaa_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            custom_contents: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            contexts_com_snowplowanalytics_snowplow_web_page_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            unstruct_event_com_snowplowanalytics_snowplow_consent_preferences_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            unstruct_event_com_snowplowanalytics_snowplow_cmp_visible_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_com_iab_snowplow_spiders_and_robots_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_com_snowplowanalytics_snowplow_ua_parser_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_nl_basjes_yauaa_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            custom_contents: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
         snowplow_base_quarantined_sessions_expected_custom:
           +column_types:
-            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
         snowplow_base_sessions_this_run_expected_custom:
           +column_types:
-            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             start_tstamp: timestamp
             end_tstamp: timestamp
         snowplow_base_events_this_run_expected_sessions_custom:
           +column_types:
-            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            app_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            platform: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            app_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            platform: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             etl_tstamp: timestamp
             collector_tstamp: timestamp
             dvce_created_tstamp: timestamp
-            event: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            event: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             txn_id: integer
-            name_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_collector: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            v_etl: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_ipaddress: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            name_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_tracker: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_collector: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            v_etl: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_id: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_ipaddress: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             domain_sessionidx: integer
-            network_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_region: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_zipcode: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            network_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_region: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_zipcode: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             geo_latitude: float
             geo_longitude: float
-            geo_region_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_isp: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_organization: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_domain: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ip_netspeed: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_url: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_title: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_referrer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            geo_region_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_isp: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_organization: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_domain: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ip_netspeed: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_url: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_title: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_referrer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             page_urlport: integer
-            page_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            page_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            page_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            page_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlscheme: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlhost: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             refr_urlport: integer
-            refr_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            refr_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_content: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_campaign: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_action: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_label: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            se_property: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            refr_urlpath: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlquery: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_urlfragment: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            refr_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_medium: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_source: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_term: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_content: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_campaign: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_action: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_label: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            se_property: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             se_value: float
-            tr_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_affiliation: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_affiliation: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             tr_total: float
             tr_tax: float
             tr_shipping: float
-            tr_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_state: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            tr_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_sku: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            ti_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_city: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_state: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            tr_country: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_orderid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_sku: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            ti_category: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             ti_price: float
             ti_quantity: integer
             pp_xoffset_min: integer
             pp_xoffset_max: integer
             pp_yoffset_min: integer
             pp_yoffset_max: integer
-            useragent: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_renderengine: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            br_lang: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            useragent: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_renderengine: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            br_lang: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             br_features_pdf: boolean
             br_features_flash: boolean
             br_features_java: boolean
@@ -762,57 +765,57 @@ seeds:
             br_features_gears: boolean
             br_features_silverlight: boolean
             br_cookies: boolean
-            br_colordepth: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            br_colordepth: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             br_viewwidth: integer
             br_viewheight: integer
-            os_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_manufacturer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            os_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            dvce_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            os_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_family: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_manufacturer: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            os_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            dvce_type: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             dvce_ismobile: boolean
             dvce_screenwidth: integer
             dvce_screenheight: integer
-            doc_charset: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            doc_charset: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             doc_width: integer
             doc_height: integer
-            tr_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            tr_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             tr_total_base: float
             tr_tax_base: float
             tr_shipping_base: float
-            ti_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            ti_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             ti_price_base: float
-            base_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            geo_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_clickid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            mkt_network: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            etl_tags: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            base_currency: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            geo_timezone: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_clickid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            mkt_network: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            etl_tags: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             dvce_sent_tstamp: timestamp
-            refr_domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            refr_domain_userid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             refr_dvce_tstamp: timestamp
-            domain_sessionid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            domain_sessionid: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             derived_tstamp: timestamp
-            event_vendor: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_format: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            event_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            event_vendor: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_name: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_format: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_version: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            event_fingerprint: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             true_tstamp: timestamp
             load_tstamp: timestamp
-            contexts_com_snowplowanalytics_snowplow_web_page_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            unstruct_event_com_snowplowanalytics_snowplow_consent_preferences_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            unstruct_event_com_snowplowanalytics_snowplow_cmp_visible_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_com_iab_snowplow_spiders_and_robots_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_com_snowplowanalytics_snowplow_ua_parser_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            contexts_nl_basjes_yauaa_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            custom_contents: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            contexts_com_snowplowanalytics_snowplow_web_page_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            unstruct_event_com_snowplowanalytics_snowplow_consent_preferences_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            unstruct_event_com_snowplowanalytics_snowplow_cmp_visible_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_com_iab_snowplow_spiders_and_robots_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_com_snowplowanalytics_snowplow_ua_parser_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            contexts_nl_basjes_yauaa_context_1_0_0: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            custom_contents: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
         snowplow_base_quarantined_sessions_expected_sessions_custom:
           +column_types:
-            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
         snowplow_base_sessions_this_run_expected_sessions_custom:
           +column_types:
-            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
-            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'varchar' }}"
+            session_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
+            user_identifier: "{{ 'string' if target.type in ['bigquery', 'databricks', 'spark'] else 'character varying(65535)' }}"
             start_tstamp: timestamp
             end_tstamp: timestamp

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils_integration_tests'
-version: '0.15.2'
+version: '0.16.0'
 config-version: 2
 
 profile: 'integration_tests'

--- a/integration_tests/macros/test_get_sde_or_context.sql
+++ b/integration_tests/macros/test_get_sde_or_context.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro test_get_sde_or_context() %}
 
     {{ return(adapter.dispatch('test_get_sde_or_context', 'snowplow_utils_integration_tests')()) }}

--- a/integration_tests/macros/test_get_successful_models.sql
+++ b/integration_tests/macros/test_get_successful_models.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# get_successful_models() macro requires the run_results object. This is only generated at the end of the run.
   This macro is intended to be run on a 'on-run-end' hook, so the run_results object is present.
   It is possible to hardcode a run_results object, however the schema for this object can evolve with time.

--- a/integration_tests/macros/test_return_limits_from_models.sql
+++ b/integration_tests/macros/test_return_limits_from_models.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro test_return_limits_from_models() %}
     {{ return(adapter.dispatch('test_return_limits_from_models', 'snowplow_utils')()) }}
 {% endmacro %}

--- a/integration_tests/models/base/actual/snowplow_base_events_this_run_actual.sql
+++ b/integration_tests/models/base/actual/snowplow_base_events_this_run_actual.sql
@@ -21,7 +21,7 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
 {% set snowplow_session_sql = '' %}
 
 {% if var('snowplow__custom_test', false) %}
-    {% set snowplow_session_identifiers = snowplow_utils.get_value_by_target_type(bigquery_val=var("snowplow__bigquery_session_identifiers"), snowflake_val=var("snowplow__snowflake_session_identifiers"), databricks_val=var("snowplow__databricks_session_identifiers"), postgres_val=var("snowplow__postgres_session_identifiers"))%}
+    {% set snowplow_session_identifiers = snowplow_utils.get_value_by_target_type(bigquery_val=var("snowplow__bigquery_session_identifiers"), snowflake_val=var("snowplow__snowflake_session_identifiers"), databricks_val=var("snowplow__databricks_session_identifiers"), postgres_val=var("snowplow__postgres_session_identifiers"), redshift_val=var("snowplow__postgres_session_identifiers"))%}
     {% set snowplow_entities_or_sdes = var("snowplow__custom_entities_or_sdes") %}
     {% set snowplow_custom_sql = snowplow_utils.get_value_by_target_type(bigquery_val=var("snowplow__bigquery_custom_sql"), snowflake_val=var("snowplow__snowflake_custom_sql"), databricks_val=var("snowplow__databricks_custom_sql"))%}
 {% elif var('snowplow__session_test', false) %}

--- a/integration_tests/models/base/actual/snowplow_base_events_this_run_actual.sql
+++ b/integration_tests/models/base/actual/snowplow_base_events_this_run_actual.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/actual/snowplow_base_new_event_limits_actual.sql
+++ b/integration_tests/models/base/actual/snowplow_base_new_event_limits_actual.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/actual/snowplow_base_quarantined_sessions_actual.sql
+++ b/integration_tests/models/base/actual/snowplow_base_quarantined_sessions_actual.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/actual/snowplow_base_sessions_lifecycle_manifest_actual.sql
+++ b/integration_tests/models/base/actual/snowplow_base_sessions_lifecycle_manifest_actual.sql
@@ -16,8 +16,8 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
 {% set snowplow_session_sql = '' %}
 
 {% if var('snowplow__custom_test', false) %}
-    {% set snowplow_session_identifiers = snowplow_utils.get_value_by_target_type(bigquery_val=var("snowplow__bigquery_session_identifiers"), snowflake_val=var("snowplow__snowflake_session_identifiers"), databricks_val=var("snowplow__databricks_session_identifiers"), postgres_val=var("snowplow__postgres_session_identifiers"))%}
-    {% set snowplow_user_identifiers = snowplow_utils.get_value_by_target_type(bigquery_val=var("snowplow__bigquery_user_identifiers"), snowflake_val=var("snowplow__snowflake_user_identifiers"), databricks_val=var("snowplow__databricks_user_identifiers"), postgres_val=var("snowplow__postgres_user_identifiers"))%}
+    {% set snowplow_session_identifiers = snowplow_utils.get_value_by_target_type(bigquery_val=var("snowplow__bigquery_session_identifiers"), snowflake_val=var("snowplow__snowflake_session_identifiers"), databricks_val=var("snowplow__databricks_session_identifiers"), postgres_val=var("snowplow__postgres_session_identifiers"), redshift_val=var("snowplow__postgres_session_identifiers"))%}
+    {% set snowplow_user_identifiers = snowplow_utils.get_value_by_target_type(bigquery_val=var("snowplow__bigquery_user_identifiers"), snowflake_val=var("snowplow__snowflake_user_identifiers"), databricks_val=var("snowplow__databricks_user_identifiers"), postgres_val=var("snowplow__postgres_user_identifiers"), redshift_val=var("snowplow__postgres_user_identifiers"))%}
 {% elif var('snowplow__session_test', false) %}
     {% set snowplow_session_sql = var("snowplow__custom_session_sql") %}
 {% endif %}

--- a/integration_tests/models/base/actual/snowplow_base_sessions_lifecycle_manifest_actual.sql
+++ b/integration_tests/models/base/actual/snowplow_base_sessions_lifecycle_manifest_actual.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/actual/snowplow_base_sessions_this_run_actual.sql
+++ b/integration_tests/models/base/actual/snowplow_base_sessions_this_run_actual.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro'],

--- a/integration_tests/models/base/actual/snowplow_incremental_manifest_actual.sql
+++ b/integration_tests/models/base/actual/snowplow_incremental_manifest_actual.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/expected/snowplow_base_events_this_run_expected_stg.sql
+++ b/integration_tests/models/base/expected/snowplow_base_events_this_run_expected_stg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/expected/snowplow_base_quarantined_sessions_expected_stg.sql
+++ b/integration_tests/models/base/expected/snowplow_base_quarantined_sessions_expected_stg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/expected/snowplow_base_sessions_this_run_expected_stg.sql
+++ b/integration_tests/models/base/expected/snowplow_base_sessions_this_run_expected_stg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/source/bigquery/snowplow_events_stg.sql
+++ b/integration_tests/models/base/source/bigquery/snowplow_events_stg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/source/databricks/snowplow_events_stg.sql
+++ b/integration_tests/models/base/source/databricks/snowplow_events_stg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/source/default/snowplow_events_stg.sql
+++ b/integration_tests/models/base/source/default/snowplow_events_stg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/source/snowflake/snowplow_events_stg.sql
+++ b/integration_tests/models/base/source/snowflake/snowplow_events_stg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags=['base_macro']

--- a/integration_tests/models/base/test.sql
+++ b/integration_tests/models/base/test.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
     config(
         tags='snowplow_incremental'

--- a/integration_tests/models/incremental_hooks/expected_update_incremental_manifest_table.sql
+++ b/integration_tests/models/incremental_hooks/expected_update_incremental_manifest_table.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 select
   model,

--- a/integration_tests/models/incremental_hooks/test_get_incremental_manifest_status.sql
+++ b/integration_tests/models/incremental_hooks/test_get_incremental_manifest_status.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 {%- set all_models = snowplow_utils.get_incremental_manifest_status(ref('data_get_incremental_manifest_status'), ['a','b','c']) -%}
 {%- set partial_models = snowplow_utils.get_incremental_manifest_status(ref('data_get_incremental_manifest_status'), ['b','d']) -%}

--- a/integration_tests/models/incremental_hooks/test_get_run_limits.sql
+++ b/integration_tests/models/incremental_hooks/test_get_run_limits.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {%- set data_query -%}
   select * from {{ ref('data_get_run_limits') }}
 {%- endset -%}

--- a/integration_tests/models/incremental_hooks/test_get_successful_models/fail_model.sql
+++ b/integration_tests/models/incremental_hooks/test_get_successful_models/fail_model.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(tags=["requires_script"])
 }}

--- a/integration_tests/models/incremental_hooks/test_get_successful_models/skip_model.sql
+++ b/integration_tests/models/incremental_hooks/test_get_successful_models/skip_model.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(tags=["requires_script"])
 }}

--- a/integration_tests/models/incremental_hooks/test_get_successful_models/successful_model_1.sql
+++ b/integration_tests/models/incremental_hooks/test_get_successful_models/successful_model_1.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(tags=["requires_script"])
 }}

--- a/integration_tests/models/incremental_hooks/test_get_successful_models/successful_model_2.sql
+++ b/integration_tests/models/incremental_hooks/test_get_successful_models/successful_model_2.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(tags=["requires_script"])
 }}

--- a/integration_tests/models/incremental_hooks/test_update_incremental_manifest_table.sql
+++ b/integration_tests/models/incremental_hooks/test_update_incremental_manifest_table.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{ config(post_hook="{{ snowplow_utils.update_incremental_manifest_table(this,
                                                                          ref('data_update_incremental_manifest_table'),
                                                                         ['a','b','c']) }}",

--- a/integration_tests/models/materializations/default_strategy/test_incremental.sql
+++ b/integration_tests/models/materializations/default_strategy/test_incremental.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Tests both RS/PG (delete/insert) and BQ/Snowflake/Databricks (merge) incremental materialization
    upsert_date_key: RS/PG/Databricks only. Key used to limit the table scan
    partition_by: BQ only. Key used to limit table scan

--- a/integration_tests/models/materializations/default_strategy/test_incremental_w_lookback_disabled.sql
+++ b/integration_tests/models/materializations/default_strategy/test_incremental_w_lookback_disabled.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Tests both RS/PG (delete/insert) and BQ/Snowflake/Databricks (merge)
 incremental materialization with lookback disabled.
    upsert_date_key: RS/PG/Databricks only. Key used to limit the table scan

--- a/integration_tests/models/materializations/snowflake_delete_insert/test_incremental_delete_insert.sql
+++ b/integration_tests/models/materializations/snowflake_delete_insert/test_incremental_delete_insert.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Tests both RS, PG (delete/insert) and BQ/Snowflake (merge) incremental materialization
    upsert_date_key: RS, PG only. Key used to limit the table scan
    partition_by: BQ only. Key used to limit table scan

--- a/integration_tests/models/materializations/snowflake_delete_insert/test_incremental_delete_insert_w_lookback_disabled.sql
+++ b/integration_tests/models/materializations/snowflake_delete_insert/test_incremental_delete_insert_w_lookback_disabled.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Tests both RS, PG (delete/insert) and BQ/Snowflake (merge) incremental materialization with lookback disabled.
    upsert_date_key: RS, PG only. Key used to limit the table scan
    partition_by: BQ only. Key used to limit table scan #}

--- a/integration_tests/models/utils/bigquery/data_combine_column_versions.sql
+++ b/integration_tests/models/utils/bigquery/data_combine_column_versions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 -- Breaking convention and using a model to seed data rather than csv.
 -- Easier to construct RECORDs in sql than string in csv.
 -- BQ Only

--- a/integration_tests/models/utils/bigquery/expected_combine_column_versions.sql
+++ b/integration_tests/models/utils/bigquery/expected_combine_column_versions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 with prep as (
   select

--- a/integration_tests/models/utils/bigquery/test_combine_column_versions.sql
+++ b/integration_tests/models/utils/bigquery/test_combine_column_versions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 {# Test 1: Select all fields from array of structs, taking second element.
    Test 2: Select subset of fields from nested structs & rename

--- a/integration_tests/models/utils/cross_db/cross_db.yml
+++ b/integration_tests/models/utils/cross_db/cross_db.yml
@@ -17,3 +17,5 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('expected_get_field_bq')
+          config:
+            +enabled: "{{  target.type in ['bigquery'] | as_bool() }}"

--- a/integration_tests/models/utils/cross_db/cross_db.yml
+++ b/integration_tests/models/utils/cross_db/cross_db.yml
@@ -19,3 +19,7 @@ models:
           compare_model: ref('expected_get_field_bq')
           config:
             +enabled: "{{  target.type in ['bigquery'] | as_bool() }}"
+  - name: test_indexed_unnest
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_indexed_unnest')

--- a/integration_tests/models/utils/cross_db/data_get_field.sql
+++ b/integration_tests/models/utils/cross_db/data_get_field.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(
     tags = ['get_field'],

--- a/integration_tests/models/utils/cross_db/data_get_string_agg.sql
+++ b/integration_tests/models/utils/cross_db/data_get_string_agg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Everything says int but I've made some of them decimals to test that as well #}
 
 {{

--- a/integration_tests/models/utils/cross_db/data_get_string_agg_grp.sql
+++ b/integration_tests/models/utils/cross_db/data_get_string_agg_grp.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 with data as (
 
   select

--- a/integration_tests/models/utils/cross_db/data_indexed_unnest.sql
+++ b/integration_tests/models/utils/cross_db/data_indexed_unnest.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Everything says int but I've made some of them decimals to test that as well #}
 
 {{

--- a/integration_tests/models/utils/cross_db/data_indexed_unnest.sql
+++ b/integration_tests/models/utils/cross_db/data_indexed_unnest.sql
@@ -1,0 +1,27 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Community License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+#}
+
+{# Everything says int but I've made some of them decimals to test that as well #}
+
+{{
+  config(
+    materialized = 'table',
+    )
+}}
+
+with data as (
+
+  select
+    test_type,
+    {{ snowplow_utils.get_split_to_array('result', 'g', ';') }} as test_array
+    
+  from {{ ref('expected_get_string_agg')}} g
+  
+  where test_type in ('string_def_colon_false_false', 'string_string_colon_false_true', 'int_def_colon_false_true')
+)
+
+select * from data

--- a/integration_tests/models/utils/cross_db/expected_get_field.sql
+++ b/integration_tests/models/utils/cross_db/expected_get_field.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(
     tags = ['get_field'],

--- a/integration_tests/models/utils/cross_db/expected_get_field_bq.sql
+++ b/integration_tests/models/utils/cross_db/expected_get_field_bq.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(
     tags = ['get_field'],

--- a/integration_tests/models/utils/cross_db/expected_get_string_agg.sql
+++ b/integration_tests/models/utils/cross_db/expected_get_string_agg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(
     materialized = 'table',

--- a/integration_tests/models/utils/cross_db/expected_get_string_agg_grp.sql
+++ b/integration_tests/models/utils/cross_db/expected_get_string_agg_grp.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 select 'a,b' as result, 'y' as grp
 union all

--- a/integration_tests/models/utils/cross_db/expected_indexed_unnest.sql
+++ b/integration_tests/models/utils/cross_db/expected_indexed_unnest.sql
@@ -1,0 +1,109 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Community License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+#}
+
+  select
+  'string_def_colon_false_false' as test_type,
+  'a' as element,
+  0 as source_index
+  
+  union all
+  
+  select
+  'string_def_colon_false_false' as test_type,
+  'b' as element,
+  1 as source_index
+  
+  union all
+  
+  select
+  'string_def_colon_false_false' as test_type,
+  'c' as element,
+  2 as source_index
+  
+  union all
+  
+  select
+  'string_def_colon_false_false' as test_type,
+  'c' as element,
+  3 as source_index
+  
+  union all
+  
+  select
+  'string_def_colon_false_false' as test_type,
+  'd' as element,
+  4 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'c' as element,
+  0 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'd' as element,
+  1 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'b' as element,
+  2 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'c' as element,
+  3 as source_index
+  
+  union all
+  
+  select
+  'string_string_colon_false_true' as test_type,
+  'a' as element,
+  4 as source_index
+  
+  union all 
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '4' as element,
+  0 as source_index
+  
+  union all
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '3' as element,
+  1 as source_index
+  
+  union all
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '3' as element,
+  2 as source_index
+  
+  union all
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '2' as element,
+  3 as source_index
+  
+  union all
+  
+  select
+  'int_def_colon_false_true' as test_type,
+  '1' as element,
+  4 as source_index

--- a/integration_tests/models/utils/cross_db/expected_indexed_unnest.sql
+++ b/integration_tests/models/utils/cross_db/expected_indexed_unnest.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
   select
   'string_def_colon_false_false' as test_type,
   'a' as element,

--- a/integration_tests/models/utils/cross_db/test_get_field.sql
+++ b/integration_tests/models/utils/cross_db/test_get_field.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(
     tags = ['get_field'],

--- a/integration_tests/models/utils/cross_db/test_get_field_bq.sql
+++ b/integration_tests/models/utils/cross_db/test_get_field_bq.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(
     tags = ['get_field'],

--- a/integration_tests/models/utils/cross_db/test_get_string_agg.sql
+++ b/integration_tests/models/utils/cross_db/test_get_string_agg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{
   config(
     materialized = 'table',

--- a/integration_tests/models/utils/cross_db/test_get_string_agg_grp.sql
+++ b/integration_tests/models/utils/cross_db/test_get_string_agg_grp.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 with data as (
 select * from {{ ref('data_get_string_agg_grp') }}
 )

--- a/integration_tests/models/utils/cross_db/test_indexed_unnest.sql
+++ b/integration_tests/models/utils/cross_db/test_indexed_unnest.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 with data as (
   

--- a/integration_tests/models/utils/cross_db/test_indexed_unnest.sql
+++ b/integration_tests/models/utils/cross_db/test_indexed_unnest.sql
@@ -1,0 +1,15 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Community License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+#}
+
+
+with data as (
+  
+  select * from {{ ref('data_indexed_unnest')}}
+)
+
+{{ snowplow_utils.unnest('test_type', 'test_array', 'element', 'data', with_index=true) }}
+

--- a/integration_tests/models/utils/expected_app_id_filter.sql
+++ b/integration_tests/models/utils/expected_app_id_filter.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 with data as (
 select * from {{ ref('data_app_id_filter') }}

--- a/integration_tests/models/utils/expected_snowplow_delete_from_manifest.sql
+++ b/integration_tests/models/utils/expected_snowplow_delete_from_manifest.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{ config(tags=["requires_script"]) }}
 
 select *

--- a/integration_tests/models/utils/test_app_id_filter.sql
+++ b/integration_tests/models/utils/test_app_id_filter.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 with data as (
 select * from {{ ref('data_app_id_filter') }}

--- a/integration_tests/models/utils/test_snowplow_delete_from_manifest.sql
+++ b/integration_tests/models/utils/test_snowplow_delete_from_manifest.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{ config(pre_hook="{{ snowplow_utils.snowplow_delete_from_manifest(
 														models=var('models_to_delete',[]),
 														incremental_manifest_table=ref('data_snowplow_delete_from_manifest_staging')) }}",

--- a/integration_tests/tests/incremental_hooks/test_get_enabled_snowplow_models.sql
+++ b/integration_tests/tests/incremental_hooks/test_get_enabled_snowplow_models.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Tests:
    1 - Find all enabled models with the snowplow_web_incremental tag
    2 - Find subset of enabled and tagged models using the dbt ls command. Performed via bash script

--- a/integration_tests/tests/utils/bigquery/combine_column_versions/test_coalesce_field_paths.sql
+++ b/integration_tests/tests/utils/bigquery/combine_column_versions/test_coalesce_field_paths.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{ config(enabled=(target.type == 'bigquery' | as_bool()) )}}
 
 {% set tests_yml %}

--- a/integration_tests/tests/utils/bigquery/combine_column_versions/test_get_field_alias.sql
+++ b/integration_tests/tests/utils/bigquery/combine_column_versions/test_get_field_alias.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{ config(enabled=(target.type == 'bigquery' | as_bool()) )}}
 
 {% set tests = [

--- a/integration_tests/tests/utils/bigquery/combine_column_versions/test_get_level_limit.sql
+++ b/integration_tests/tests/utils/bigquery/combine_column_versions/test_get_level_limit.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{ config(enabled=(target.type == 'bigquery' | as_bool()) )}}
 
 {% set tests_yml %}

--- a/integration_tests/tests/utils/bigquery/combine_column_versions/test_get_matched_fields.sql
+++ b/integration_tests/tests/utils/bigquery/combine_column_versions/test_get_matched_fields.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{ config(enabled=(target.type == 'bigquery' | as_bool()) )}}
 
 {% set tests_yml %}

--- a/integration_tests/tests/utils/bigquery/combine_column_versions/test_merge_fields_across_col_versions.sql
+++ b/integration_tests/tests/utils/bigquery/combine_column_versions/test_merge_fields_across_col_versions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {{ config(enabled=(target.type == 'bigquery' | as_bool()) )}}
 
 {% set tests_yml %}

--- a/integration_tests/tests/utils/bigquery/test_get_columns_in_relation_by_column_prefix.sql
+++ b/integration_tests/tests/utils/bigquery/test_get_columns_in_relation_by_column_prefix.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# TODO: add test for compiler error if no columns matched #}
 
 {% set actual_matched_columns = snowplow_utils.get_columns_in_relation_by_column_prefix(relation=ref('data_get_columns_in_relation_by_column_prefix'),

--- a/macros/base/base_create_snowplow_events_this_run.sql
+++ b/macros/base/base_create_snowplow_events_this_run.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 {% macro base_create_snowplow_events_this_run(sessions_this_run_table='snowplow_base_sessions_this_run', session_identifiers=[{"schema" : "atomic", "field" : "domain_sessionid"}], session_sql=none, session_timestamp='load_tstamp', derived_tstamp_partitioned=true, days_late_allowed=3, max_session_days=3, app_ids=[], snowplow_events_database=none, snowplow_events_schema='atomic', snowplow_events_table='events', entities_or_sdes=none, custom_sql=none) %}
     {{ return(adapter.dispatch('base_create_snowplow_events_this_run', 'snowplow_utils')(sessions_this_run_table, session_identifiers, session_sql, session_timestamp, derived_tstamp_partitioned, days_late_allowed, max_session_days, app_ids, snowplow_events_database, snowplow_events_schema, snowplow_events_table, entities_or_sdes, custom_sql)) }}

--- a/macros/base/base_create_snowplow_incremental_manifest.sql
+++ b/macros/base/base_create_snowplow_incremental_manifest.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 {% macro base_create_snowplow_incremental_manifest() %}
 

--- a/macros/base/base_create_snowplow_quarantined_sessions.sql
+++ b/macros/base/base_create_snowplow_quarantined_sessions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 {% macro base_create_snowplow_quarantined_sessions() %}
 

--- a/macros/base/base_create_snowplow_sessions_lifecycle_manifest.sql
+++ b/macros/base/base_create_snowplow_sessions_lifecycle_manifest.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Add quarantined_sessions reference properly #}
 {% macro base_create_snowplow_sessions_lifecycle_manifest(session_identifiers=[{"schema": "atomic", "field" : "domain_sessionid"}], session_sql=none, session_timestamp='load_tstamp', user_identifiers=[{"schema": "atomic", "field" : "domain_userid"}], user_sql=none, quarantined_sessions=none, derived_tstamp_partitioned=true, days_late_allowed=3, max_session_days=3, app_ids=[], snowplow_events_database=none, snowplow_events_schema='atomic', snowplow_events_table='events', event_limits_table='snowplow_base_new_event_limits', incremental_manifest_table='snowplow_incremental_manifest', package_name='snowplow') %}
     {{ return(adapter.dispatch('base_create_snowplow_sessions_lifecycle_manifest', 'snowplow_utils')(session_identifiers, session_sql, session_timestamp, user_identifiers, user_sql, quarantined_sessions, derived_tstamp_partitioned, days_late_allowed, max_session_days, app_ids, snowplow_events_database, snowplow_events_schema, snowplow_events_table, event_limits_table, incremental_manifest_table, package_name)) }}

--- a/macros/base/base_create_snowplow_sessions_this_run.sql
+++ b/macros/base/base_create_snowplow_sessions_this_run.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro base_create_snowplow_sessions_this_run(lifecycle_manifest_table='snowplow_base_sessions_lifecycle_manifest', new_event_limits_table='snowplow_base_new_event_limits') %}
     {% set lifecycle_manifest = ref(lifecycle_manifest_table) %}
     {% set new_event_limits = ref(new_event_limits_table) %}

--- a/macros/base/base_quarantine_sessions.sql
+++ b/macros/base/base_quarantine_sessions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro base_quarantine_sessions(max_session_length, quarantined_sessions='snowplow_base_quarantined_sessions', src_relation=this) %}
 
   {{ return(adapter.dispatch('base_quarantine_sessions', 'snowplow_utils')(max_session_length, quarantined_sessions, src_relation)) }}

--- a/macros/incremental_hooks/get_enabled_snowplow_models.sql
+++ b/macros/incremental_hooks/get_enabled_snowplow_models.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Returns an array of enabled models tagged with snowplow_web_incremental using dbts graph object.
   Throws an error if untagged models are found that depend on the base_events_this_run model
 #}

--- a/macros/incremental_hooks/get_incremental_manifest_status.sql
+++ b/macros/incremental_hooks/get_incremental_manifest_status.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_incremental_manifest_status(incremental_manifest_table, models_in_run) -%}
 
   {# In case of not execute just return empty strings to avoid hitting database #}

--- a/macros/incremental_hooks/get_incremental_manifest_table_relation.sql
+++ b/macros/incremental_hooks/get_incremental_manifest_table_relation.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Returns the incremental manifest table reference.
 This table contains 1 row/model with the latest tstamp consumed #}
 

--- a/macros/incremental_hooks/get_new_event_limits_table_relation.sql
+++ b/macros/incremental_hooks/get_new_event_limits_table_relation.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Returns the new events limits table reference.
 This table contains lower and upper tstamp limits of the current run #}
 

--- a/macros/incremental_hooks/get_run_limits.sql
+++ b/macros/incremental_hooks/get_run_limits.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Returns the sql to calculate the lower/upper limits of the run #}
 {% macro get_run_limits(min_last_success, max_last_success, models_matched_from_manifest, has_matched_all_models, start_date) -%}
 

--- a/macros/incremental_hooks/get_session_lookback_limit.sql
+++ b/macros/incremental_hooks/get_session_lookback_limit.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_session_lookback_limit(lower_limit) %}
 
   {% if not execute %}

--- a/macros/incremental_hooks/get_successful_models.sql
+++ b/macros/incremental_hooks/get_successful_models.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Returns an array of successfully executed models by name #}
 {% macro get_successful_models(models=[], run_results=results) -%}
 

--- a/macros/incremental_hooks/quarantine_sessions.sql
+++ b/macros/incremental_hooks/quarantine_sessions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro quarantine_sessions(package_name, max_session_length, src_relation=this) %}
 
   {{ return(adapter.dispatch('quarantine_sessions', 'snowplow_utils')(package_name, max_session_length, src_relation=this)) }}

--- a/macros/incremental_hooks/return_base_new_event_limits.sql
+++ b/macros/incremental_hooks/return_base_new_event_limits.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro return_base_new_event_limits(base_events_this_run) -%}
 
   {# In case of not execute just return empty strings to avoid hitting database #}

--- a/macros/incremental_hooks/snowplow_incremental_post_hook.sql
+++ b/macros/incremental_hooks/snowplow_incremental_post_hook.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# post-hook for incremental runs #}
 {% macro snowplow_incremental_post_hook(package_name='snowplow', incremental_manifest_table_name=none, base_events_this_run_table_name=none, session_timestamp=var('snowplow__session_timestamp', 'load_tstamp')) %}
 

--- a/macros/incremental_hooks/update_incremental_manifest_table.sql
+++ b/macros/incremental_hooks/update_incremental_manifest_table.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Updates the incremental manifest table at the run end with the latest tstamp consumed per model #}
 {% macro update_incremental_manifest_table(manifest_table, base_events_table, models, session_timestamp=var('snowplow__session_timestamp', 'load_tstamp')) -%}
 

--- a/macros/incremental_hooks/update_incremental_manifest_table.sql
+++ b/macros/incremental_hooks/update_incremental_manifest_table.sql
@@ -51,7 +51,11 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
     begin transaction;
       --temp table to find the greatest last_success per model.
       --this protects against partial backfills causing the last_success to move back in time.
-      create temporary table snowplow_models_last_success as (
+      create temporary table snowplow_models_last_success (
+        model varchar,
+        last_success {{type_timestamp()}}
+      );
+      insert into snowplow_models_last_success (
         select
           a.model,
           greatest(a.last_success, b.last_success) as last_success

--- a/macros/materializations/base_incremental/common/get_merge_sql.sql
+++ b/macros/materializations/base_incremental/common/get_merge_sql.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro default__get_merge_sql(target_tb, source, unique_key, dest_columns, incremental_predicates = none) -%}
     {# Set default predicates to pass on #}
     {%- set predicate_override = "" -%}

--- a/macros/utils/allow_refresh.sql
+++ b/macros/utils/allow_refresh.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Default: Allow refresh in dev, block refresh otherwise. dev defined by snowplow__dev_target_name #}
 
 {% macro allow_refresh() %}

--- a/macros/utils/app_id_filter.sql
+++ b/macros/utils/app_id_filter.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro app_id_filter(app_ids) %}
 
   {%- if app_ids|length -%}

--- a/macros/utils/bigquery/combine_column_versions/coalesce_field_paths.sql
+++ b/macros/utils/bigquery/combine_column_versions/coalesce_field_paths.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro coalesce_field_paths(paths, field_alias, include_field_alias, relation_alias) %}
 
   {% set relation_alias = '' if relation_alias is none else relation_alias~'.' %}

--- a/macros/utils/bigquery/combine_column_versions/combine_column_versions.sql
+++ b/macros/utils/bigquery/combine_column_versions/combine_column_versions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro combine_column_versions(relation, column_prefix, required_fields=[], nested_level=none, level_filter='equalto', relation_alias=none, include_field_alias=true, array_index=0, max_nested_level=15, exclude_versions=[]) %}
 
   {# Create field_alias if not supplied i.e. is not tuple #}

--- a/macros/utils/bigquery/combine_column_versions/exclude_column_versions.sql
+++ b/macros/utils/bigquery/combine_column_versions/exclude_column_versions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro exclude_column_versions(columns, exclude_versions) %}
   {%- set filtered_columns_by_version = [] -%}
   {% for column in columns %}

--- a/macros/utils/bigquery/combine_column_versions/flatten_fields.sql
+++ b/macros/utils/bigquery/combine_column_versions/flatten_fields.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro flatten_fields(fields, parent, path, array_index, level_limit=none, level_counter=1, flattened_fields=[], field_name='') %}
 
   {% for field in fields %}

--- a/macros/utils/bigquery/combine_column_versions/get_field_alias.sql
+++ b/macros/utils/bigquery/combine_column_versions/get_field_alias.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# returns tuple: (field_name, field_alias) #}
 {% macro get_field_alias(field) %}
 

--- a/macros/utils/bigquery/combine_column_versions/get_level_limit.sql
+++ b/macros/utils/bigquery/combine_column_versions/get_level_limit.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_level_limit(level, level_filter, required_field_names) %}
 
   {% set accepted_level_filters = ['equalto','lessthan','greaterthan'] %}

--- a/macros/utils/bigquery/combine_column_versions/get_matched_fields.sql
+++ b/macros/utils/bigquery/combine_column_versions/get_matched_fields.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_matched_fields(fields, required_field_names, nested_level, level_filter) %}
 
   {% if not required_field_names|length %}

--- a/macros/utils/bigquery/combine_column_versions/merge_fields_across_col_versions.sql
+++ b/macros/utils/bigquery/combine_column_versions/merge_fields_across_col_versions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro merge_fields_across_col_versions(fields_by_col_version) %}
 
   {# Flatten nested list of dicts into single list #}

--- a/macros/utils/bigquery/get_optional_fields.sql
+++ b/macros/utils/bigquery/get_optional_fields.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_optional_fields(enabled, fields, col_prefix, relation, relation_alias, include_field_alias=true) -%}
 
   {%- if enabled -%}

--- a/macros/utils/cross_db/cluster_by_fields.sql
+++ b/macros/utils/cross_db/cluster_by_fields.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro cluster_by_fields_sessions_lifecycle() %}
 
   {{ return(adapter.dispatch('cluster_by_fields_sessions_lifecycle', 'snowplow_utils')()) }}

--- a/macros/utils/cross_db/datatypes.sql
+++ b/macros/utils/cross_db/datatypes.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# string  -------------------------------------------------     #}
 
 {%- macro type_max_string() -%}

--- a/macros/utils/cross_db/get_array_size.sql
+++ b/macros/utils/cross_db/get_array_size.sql
@@ -1,0 +1,30 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Community License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+#}
+
+{#
+    Takes care of harmonising cross-db functions that create a string out of an array.
+#}
+
+{%- macro get_array_size(array_column) -%}
+    {{ return(adapter.dispatch('get_array_size', 'snowplow_utils')(array_column)) }}
+{%- endmacro -%}
+
+{% macro default__get_array_size(array_column) %}
+    array_size({{array_column}})
+{% endmacro %}
+
+{% macro bigquery__get_array_size(array_column) %}
+  array_length({{array_column}})
+{% endmacro %}
+
+{% macro postgres__get_array_size(array_column) %}
+    array_length({{array_column}})
+{% endmacro %}
+
+{% macro redshift__get_array_size(array_column) %}
+  get_array_length({{array_column}})
+{% endmacro %}

--- a/macros/utils/cross_db/get_array_size.sql
+++ b/macros/utils/cross_db/get_array_size.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {#
     Takes care of harmonising cross-db functions that create a string out of an array.
 #}

--- a/macros/utils/cross_db/get_array_to_string.sql
+++ b/macros/utils/cross_db/get_array_to_string.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {#
     Takes care of harmonising cross-db functions that create a string out of an array.
 #}

--- a/macros/utils/cross_db/get_field.sql
+++ b/macros/utils/cross_db/get_field.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_field(column_name, field_name, table_alias = none, type = none, array_index = none, relation = none) %}
     {{ return(adapter.dispatch('get_field', 'snowplow_utils')(column_name, field_name, table_alias, type, array_index, relation)) }}
 {% endmacro %}

--- a/macros/utils/cross_db/get_split_to_array.sql
+++ b/macros/utils/cross_db/get_split_to_array.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {#
     Takes care of harmonising cross-db functions that create an array out of a string.
 #}

--- a/macros/utils/cross_db/get_string_agg.sql
+++ b/macros/utils/cross_db/get_string_agg.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {#
   Takes care of harmonising cross-db list_agg, string_agg type functions.
 #}

--- a/macros/utils/cross_db/timestamp_functions.sql
+++ b/macros/utils/cross_db/timestamp_functions.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 
 {#
     datediff/dateadd functions in dbt_utils cast tstamps to datetimes for BQ.

--- a/macros/utils/cross_db/unnest.sql
+++ b/macros/utils/cross_db/unnest.sql
@@ -9,31 +9,36 @@ You may obtain a copy of the Snowplow Community License Version 1.0 at https://d
     Takes care of harmonising cross-db unnesting.
 #}
 
-{%- macro unnest(id_column, unnest_column, field_alias, source_table) -%}
-    {{ return(adapter.dispatch('unnest', 'snowplow_utils')(id_column, unnest_column, field_alias, source_table)) }}
+{%- macro unnest(id_column, unnest_column, field_alias, source_table, with_index=false) -%}
+    {{ return(adapter.dispatch('unnest', 'snowplow_utils')(id_column, unnest_column, field_alias, source_table, with_index)) }}
 {%- endmacro -%}
 
-{% macro default__unnest(id_column, unnest_column, field_alias, source_table) %}
-    select {{ id_column }}, explode({{ unnest_column }}) as {{ field_alias }}
-    from {{ source_table }}
+{% macro default__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
+    {% if with_index %}
+        select {{ id_column }}, posexplode({{ unnest_column }}) as (source_index, {{ field_alias }})
+    {% else %}
+        select {{ id_column }}, explode({{ unnest_column }}) as {{ field_alias }}
+    {% endif %}
+        from {{ source_table }}
 {% endmacro %}
 
-{% macro bigquery__unnest(id_column, unnest_column, field_alias, source_table) %}
-    select {{ id_column }}, r as {{ field_alias }}
-    from {{ source_table }} t, unnest(t.{{ unnest_column }}) r
+{% macro bigquery__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
+    select {{ id_column }}, r as {{ field_alias }} {% if with_index %}, source_index {% endif %}
+    from {{ source_table }} t, unnest(t.{{ unnest_column }}) r {% if with_index %} WITH OFFSET AS source_index {% endif %}
 {% endmacro %}
 
-{% macro snowflake__unnest(id_column, unnest_column, field_alias, source_table) %}
+{% macro snowflake__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
     select t.{{ id_column }}, replace(r.value, '"', '') as {{ field_alias }}
+    {% if with_index %}, r.index as source_index {% endif %}
     from {{ source_table }} t, table(flatten(t.{{ unnest_column }})) r
 {% endmacro %}
 
-{% macro postgres__unnest(id_column, unnest_column, field_alias, source_table) %}
+{% macro postgres__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
     select {{ id_column }}, trim(unnest({{ unnest_column }})) as {{ field_alias }}
     from {{ source_table }}
 {% endmacro %}
 
-{% macro redshift__unnest(id_column, unnest_column, field_alias, source_table) %}
-    select {{ id_column }}, {{ field_alias }}
-    from {{ source_table }} p, p.{{ unnest_column }} as {{ field_alias }}
+{% macro redshift__unnest(id_column, unnest_column, field_alias, source_table, with_index=false) %}
+    select {{ id_column }}, {{ field_alias }} {% if with_index %} , index as source_index
+    from {{ source_table }} p, p.{{ unnest_column }} as {{ field_alias }} at index {% endif %} 
 {% endmacro %}

--- a/macros/utils/cross_db/unnest.sql
+++ b/macros/utils/cross_db/unnest.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {#
     Takes care of harmonising cross-db unnesting.
 #}

--- a/macros/utils/get_cluster_by.sql
+++ b/macros/utils/get_cluster_by.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_cluster_by(bigquery_cols=none, snowflake_cols=none) %}
 
   {%- do exceptions.warn("Warning: the `get_cluster_by` macro is deprecated and will be removed in a future version of the package, please use `get_value_by_target_type` instead.") -%}

--- a/macros/utils/get_columns_in_relation_by_column_prefix.sql
+++ b/macros/utils/get_columns_in_relation_by_column_prefix.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_columns_in_relation_by_column_prefix(relation, column_prefix) %}
 
   {# Prevent introspective queries during parsing #}

--- a/macros/utils/get_partition_by.sql
+++ b/macros/utils/get_partition_by.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {%- macro get_partition_by(bigquery_partition_by=none, databricks_partition_by=none) -%}
 
   {%- do exceptions.warn("Warning: the `get_partition_by` macro is deprecated and will be removed in a future version of the package, please use `get_value_by_target_type` instead.") -%}

--- a/macros/utils/get_schemas_by_pattern.sql
+++ b/macros/utils/get_schemas_by_pattern.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_schemas_by_pattern(schema_pattern) %}
     {{ return(adapter.dispatch('get_schemas_by_pattern', 'snowplow_utils')
         (schema_pattern)) }}

--- a/macros/utils/get_sde_or_context.sql
+++ b/macros/utils/get_sde_or_context.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_sde_or_context(schema, identifier, lower_limit, upper_limit, prefix = none, single_entity = true) %}
     {{ return(adapter.dispatch('get_sde_or_context', 'snowplow_utils')(schema, identifier, lower_limit, upper_limit, prefix, single_entity)) }}
 {% endmacro %}

--- a/macros/utils/get_value_by_target.sql
+++ b/macros/utils/get_value_by_target.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro get_value_by_target(dev_value, default_value, dev_target_name='dev') %}
 
   {% if target.name == dev_target_name %}

--- a/macros/utils/get_value_by_target_type.sql
+++ b/macros/utils/get_value_by_target_type.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {%- macro get_value_by_target_type(bigquery_val=none, snowflake_val=none, redshift_val=none, postgres_val=none, databricks_val=none) -%}
 
   {% if target.type == 'bigquery' %}

--- a/macros/utils/is_run_with_new_events.sql
+++ b/macros/utils/is_run_with_new_events.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro is_run_with_new_events(package_name, new_event_limits_table=none, incremental_manifest_table=none, base_sessions_lifecycle_table=none) %}
 
   {%- if new_event_limits_table -%}

--- a/macros/utils/log_message.sql
+++ b/macros/utils/log_message.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro log_message(message, is_printed=var('snowplow__has_log_enabled', true)) %}
     {{ log(dbt_utils.pretty_log_format(message), info=is_printed) }}
 {% endmacro %}

--- a/macros/utils/n_timedeltas_ago.sql
+++ b/macros/utils/n_timedeltas_ago.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro n_timedeltas_ago(n, timedelta_attribute) %}
 
   {% set arg_dict = {timedelta_attribute: n} %}

--- a/macros/utils/post_ci_cleanup.sql
+++ b/macros/utils/post_ci_cleanup.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Destructive macro. Use with care! #}
 
 {% macro post_ci_cleanup(schema_pattern=target.schema) %}

--- a/macros/utils/print_list.sql
+++ b/macros/utils/print_list.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro print_list(list, separator = ',') %}
 
   {%- for item in list %} '{{item}}' {%- if not loop.last %}{{separator}}{% endif %} {% endfor -%}

--- a/macros/utils/return_limits_from_model.sql
+++ b/macros/utils/return_limits_from_model.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro return_limits_from_model(model, lower_limit_col, upper_limit_col) -%}
 
   {# In case of not execute just return empty strings to avoid hitting database #}

--- a/macros/utils/set_query_tag.sql
+++ b/macros/utils/set_query_tag.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {%- macro set_query_tag(statement) -%}
   {{ return(adapter.dispatch('set_query_tag', 'snowplow_utils')(statement)) }}
 {%- endmacro -%}

--- a/macros/utils/snowplow_delete_from_manifest.sql
+++ b/macros/utils/snowplow_delete_from_manifest.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Deletes specified models from the incremental_manifest table #}
 {% macro snowplow_delete_from_manifest(models, incremental_manifest_table) %}
 

--- a/macros/utils/throw_compiler_error.sql
+++ b/macros/utils/throw_compiler_error.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {# Allows for testing of compiler errors #}
 {# By disabling errors, only error message is returned without throwing compiler errors #}
 {# WARNING snowplow__disable_errors should not be set to true in normal use #}

--- a/macros/utils/tstamp_to_str.sql
+++ b/macros/utils/tstamp_to_str.sql
@@ -1,10 +1,9 @@
 {#
 Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
-This program is licensed to you under the Snowplow Community License Version 1.0,
-and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
-You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
-
 {% macro tstamp_to_str(tstamp) -%}
   '{{ tstamp.strftime("%Y-%m-%d %H:%M:%S") }}'
 {%- endmacro %}


### PR DESCRIPTION
## Summary
This release contains a new array size macro as well as the optional ability for the unnest macros to also surface the index of the original array element for preserving the order. It also contains some fixes for redshift. Please note that from this version onwards this package is under the SPAL license.

# Features
- Add get_array_size macro
- Add optional index to unnest

## Fixes
- Fix existing tests for redshift
- Fix issue with multiple end hooks failing (Close #152)

## Under the hood
- Update license to SPAL

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md

