### PR TITLE
Allow null value in app_id filter list

### DIFF
--- a/integration_tests/data/utils/data_app_id_filter.csv
+++ b/integration_tests/data/utils/data_app_id_filter.csv
@@ -1,4 +1,5 @@
-app_id
-a
-b
-c
+app_id,val
+a,1
+,1
+b,1
+c,1

--- a/integration_tests/models/utils/expected_app_id_filter.sql
+++ b/integration_tests/models/utils/expected_app_id_filter.sql
@@ -27,3 +27,31 @@ select
   *
 from data
 where app_id in ('c')
+
+union all
+
+select
+  *
+from data
+where (app_id in ('a') or app_id is null)
+
+union all
+
+select
+  *
+from data
+where app_id is null
+
+union all
+
+select
+  *
+from data
+where app_id is null
+
+union all
+
+select
+  *
+from data
+where 1=1

--- a/integration_tests/models/utils/test_app_id_filter.sql
+++ b/integration_tests/models/utils/test_app_id_filter.sql
@@ -27,3 +27,31 @@ select
   *
 from data
 where {{ snowplow_utils.app_id_filter("c") }}
+
+union all
+
+select
+  *
+from data
+where {{ snowplow_utils.app_id_filter(["a",null]) }}
+
+union all
+
+select
+  *
+from data
+where {{ snowplow_utils.app_id_filter([null]) }}
+
+union all
+
+select
+  *
+from data
+where {{ snowplow_utils.app_id_filter(null) }}
+
+union all
+
+select
+  *
+from data
+where {{ snowplow_utils.app_id_filter() }}

--- a/macros/utils/app_id_filter.sql
+++ b/macros/utils/app_id_filter.sql
@@ -5,15 +5,17 @@ and you may not use this file except in compliance with the Snowplow Personal an
 You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
 {% macro app_id_filter(app_ids) %}
-
   {%- if app_ids|length -%}
-
-    app_id in ('{{ app_ids|join("','") }}') --filter on app_id if provided
-
+  ( 
+    1=0
+    {%- if app_ids|select("defined")|list|length %}
+        or app_id in ('{{ app_ids|select("defined")|join("','") }}') --filter on app_id if provided
+    {%- endif %}
+    {%- if app_ids|select("undefined")|list|length %}
+        or app_id is null
+    {% endif %}
+  )
   {%- else -%}
-
-    true
-
+    (1=1)
   {%- endif -%}
-
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation
Allow `null` to be supplied in the app id filters list and process it correctly. Close #149 

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)

