### PR TITLE
Add parse_agg_dict macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 .DS_Store
 dbt-service-account.json
 .vscode/settings.json
+package-lock.yml

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+snowplow-utils 0.16.2 (2024-02-XX)
+---------------------------------------
+## Summary
+XXX
+
+## Fixes
+- Add new `parse_agg_dict` macro for use to generate aggregation sql in other packages
+
+## Upgrading
+To upgrade, bump the package version in your `packages.yml` file.
+
 snowplow-utils 0.16.1 (2024-01-29)
 ---------------------------------------
 ## Summary

--- a/docs/markdown/snowplow_utils_macro_docs.md
+++ b/docs/markdown/snowplow_utils_macro_docs.md
@@ -358,3 +358,26 @@ from
 
 {% endraw %}
 {% enddocs %}
+{% docs macro_parse_agg_dict %}
+{% raw %}
+
+This macro allows you to provide aggregations in a consistent and restricted way to avoid having to write the sql yourself. This is mostly for use within other packages to allow aggregations but not allow the user to add arbitrary SQL.
+
+#### Returns
+
+SQL snippet for the specified aggregation, aliased.
+
+#### Usage
+
+Extracting a single field
+```sql
+
+select
+{{ snowplow_utils.parse_agg_dict({'type': 'countd', 'field': 'event_name', 'alias': 'distinct_event_types'})}}
+from 
+    my_events_table a
+
+```
+
+{% endraw %}
+{% enddocs %}

--- a/integration_tests/data/utils/data_parse_agg_dict.csv
+++ b/integration_tests/data/utils/data_parse_agg_dict.csv
@@ -1,0 +1,4 @@
+event_name,event_value
+page_ping,1
+page_view,2
+page_ping,3

--- a/integration_tests/models/utils/expected_parse_agg_dict.sql
+++ b/integration_tests/models/utils/expected_parse_agg_dict.sql
@@ -1,0 +1,14 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
+#}
+
+select
+  2 as distinct_event_names,
+  3 as count_event_names,
+  6 as sum_event_value,
+  2 as avg_event_value,
+  1 as min_event_value,
+  3 as max_event_value

--- a/integration_tests/models/utils/test_parse_agg_dict.sql
+++ b/integration_tests/models/utils/test_parse_agg_dict.sql
@@ -1,0 +1,19 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
+#}
+
+with data as (
+select * from {{ ref('data_parse_agg_dict') }}
+)
+
+select
+  {{ snowplow_utils.parse_agg_dict({'type': 'countd', 'field': 'event_name', 'alias': 'distinct_event_names'})}},
+  {{ snowplow_utils.parse_agg_dict({'type': 'count', 'field': 'event_name', 'alias': 'count_event_names'})}},
+  {{ snowplow_utils.parse_agg_dict({'type': 'sum', 'field': 'event_value', 'alias': 'sum_event_value'})}},
+  {{ snowplow_utils.parse_agg_dict({'type': 'avg', 'field': 'event_value', 'alias': 'avg_event_value'})}},
+  {{ snowplow_utils.parse_agg_dict({'type': 'min', 'field': 'event_value', 'alias': 'min_event_value'})}},
+  {{ snowplow_utils.parse_agg_dict({'type': 'max', 'field': 'event_value', 'alias': 'max_event_value'})}}
+from data

--- a/integration_tests/models/utils/utils.yml
+++ b/integration_tests/models/utils/utils.yml
@@ -9,3 +9,7 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('expected_snowplow_delete_from_manifest')
+  - name: test_parse_agg_dict
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected_parse_agg_dict')

--- a/macros/utils/parse_agg_dict.sql
+++ b/macros/utils/parse_agg_dict.sql
@@ -1,0 +1,32 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
+#}
+{% macro parse_agg_dict(agg_dict) %}
+  {{ return(adapter.dispatch('parse_agg_dict', 'snowplow_utils')(agg_dict)) }}
+{% endmacro %}
+
+{% macro default__parse_agg_dict(agg_dict) %}
+  {% set agg_type = agg_dict.get('type') %}
+  {% set agg_field = agg_dict.get('field') %}
+  {% set agg_alias = agg_dict.get('alias') %}
+
+  {% if agg_type not in ['sum', 'avg', 'min', 'max', 'count', 'countd'] or not agg_type %}
+    {{ exceptions.raise_compiler_error(
+      "Snowplow Error: Unexpected aggregation provided, must be one of sum, avg, min, max, count, countd (count distinct), not "~agg_type~"."
+    ) }}
+  {% endif %}
+  {% if not agg_alias %}
+    {{ exceptions.raise_compiler_error(
+      "Snowplow Error: Alias must be provided for all aggregations."
+    ) }}
+  {% endif %}
+  {% if agg_type == 'countd' %}
+    count(distinct {{ agg_field }}) as {{ agg_alias }}
+  {% else %}
+    {{ agg_type }}({{ agg_field }}) as {{ agg_alias }}
+  {% endif %}
+
+{% endmacro %}

--- a/macros/utils/schema.yml
+++ b/macros/utils/schema.yml
@@ -125,3 +125,9 @@ macros:
       - name: prefix
         type: string
         description: A string to prefix (additional `_` added automatically) the column names with. If not provided `root_id` and `root_tstamp` will be prefixed with the schema name.
+  - name: parse_agg_dict
+    description: '{{ doc("macro_parse_agg_dict") }}'
+    arguments:
+      - name: agg_dict
+        type: dict
+        description: The dictonary to parse, with keys `type`, `field`, and `alias`


### PR DESCRIPTION
## Description & motivation
Adds a parse_agg_dict macro to allow us to use it in downstream packages without having to re-implement it every time.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
