### PR TITLE
Feature/add apply grants

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,8 +3,11 @@ snowplow-utils 0.16.2 (2024-02-XX)
 ## Summary
 XXX
 
-## Fixes
+## Features
 - Add new `parse_agg_dict` macro for use to generate aggregation sql in other packages
+- Overwrite default dbt `apply_grants` macro to enable using a variable to define grant targets
+- Add new `grant_usage_on_schemas_where_select` macro to add as a post-hook in package to grant usage for schemas
+
 
 ## Upgrading
 To upgrade, bump the package version in your `packages.yml` file.

--- a/macros/incremental_hooks/apply_grants.sql
+++ b/macros/incremental_hooks/apply_grants.sql
@@ -1,0 +1,47 @@
+{#
+Copyright (c) 2021-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
+#}
+
+{# Note this does not work for bigquery due to the role/IAM type approach they have to grants, so BQ users should not supply values to this var #}
+{% macro default__apply_grants(relation, grant_config, should_revoke=True) %}
+    {# 
+        We only want to enforce this if the package user is managing grants this way - if they are doing it in database we should 
+        pass {} so that it's a no-op 
+    #}
+    {% if (grant_config.get('select', []) or var('snowplow__grant_select_list', [])) and target.type != 'bigquery' %}
+        {# Add our config to the grants from our variable #}
+        {% do grant_config.update({'select': grant_config.get('select', []) + var('snowplow__grant_select_list', [])}) %}
+    {% endif %}
+    {# Call the original macro so we don't have to keep this in sync ourselves #}
+    {{ dbt.default__apply_grants(relation, grant_config, should_revoke=True) }}
+{% endmacro %}
+
+{% macro grant_usage_on_schemas_built_into(enabled=false) -%}
+
+  {{ return(adapter.dispatch('grant_usage_on_schemas_built_into', 'snowplow_utils')(enabled)) }}
+
+{% endmacro %}
+
+{% macro default__grant_usage_on_schemas_built_into(enabled=true) %}
+    {% if enabled %}
+        {% if execute %}
+            {% set grant_list %}
+                {% for schema in schemas %}
+                    {% for role in var('snowplow__grant_select_list', []) %}
+                        grant usage on schema {{ schema }} to {% if target.type == 'databricks' %}`{% else %}"{% endif %}{{ role }}{% if target.type == 'databricks' %}`{% else %}"{% endif %};
+                    {% endfor %}
+                {% endfor %}
+            {% endset %}
+            {{ return(grant_list) }}
+        {% endif %}
+    {% endif %}
+    {{ return("") }}
+{% endmacro %}
+
+{% macro bigquery__grant_usage_on_schemas_built_into(enabled=false) %}
+    {# Bigquery doesn't need usage granted on schemas #}
+    {{ return("") }}
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation
Adds the ability to overwrite the default dbt macro for grants to also use the `snowplow__grants_list` variable to grant select on all the tables created. Also adds a post hook that we can add to our packages to grant usages on any created schemas.

I have tested this works as expected, although does require case-sensitive roles/users, on Snowflake, Databricks, and Redshift. Bigquery will not be supported due to their weird grant system.

The variable will ensure that it's scope will only grant tables at it's scope (e.g. scoped to a package, will only grant those in a package). However, the schema grants will apply to any schemas written to, I will make this clear in the docs.

I haven't added tests because without adding multiple users it's not really possible, we'll have to manually test changes to this if they occur.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)

