### PR TITLE
Add max clause around user identifier custom sql

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ XXX
 - Add new `parse_agg_dict` macro for use to generate aggregation sql in other packages
 - Overwrite default dbt `apply_grants` macro to enable using a variable to define grant targets
 - Add new `grant_usage_on_schemas_where_select` macro to add as a post-hook in package to grant usage for schemas
-
+- Ensure only one user id even when a custom user sql is provided for the lifecycles manifest table
 
 ## Upgrading
 To upgrade, bump the package version in your `packages.yml` file.

--- a/macros/base/base_create_snowplow_sessions_lifecycle_manifest.sql
+++ b/macros/base/base_create_snowplow_sessions_lifecycle_manifest.sql
@@ -38,7 +38,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
                 {% do exceptions.raise_compiler_error("Need to specify either session identifiers or custom session SQL") %}
             {%- endif %}
             {%- if user_sql -%}
-                {{ user_sql }} as user_identifier,
+                max({{ user_sql }}) as user_identifier,
             {%- elif user_identifiers|length > 0 %}
                 max(
                     COALESCE(
@@ -189,7 +189,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
                 {% do exceptions.raise_compiler_error("Need to specify either session identifiers or custom session SQL") %}
             {% endif %}
             {% if user_sql %}
-                {{ user_sql }} as user_identifier,
+                max({{ user_sql }}) as user_identifier,
             {% elif user_identifiers|length > 0 %}
                 max(
                     COALESCE(


### PR DESCRIPTION
## Description & motivation
It's possible a user could provide a non-unique user identifier for a session via custom sql, this ensures we take the max as we do with non-custom sql

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)


