### PR TITLE
Remove hardcoded limit of exclude versions length

### DIFF
--- a/integration_tests/models/utils/bigquery/data_combine_column_versions.sql
+++ b/integration_tests/models/utils/bigquery/data_combine_column_versions.sql
@@ -38,7 +38,13 @@ with data as (
               struct('remote' as name, 22 as price)
             ] as accessories
         ) as specs
-    ) as product_v1
+    ) as product_v1,
+    struct('Alice' as f_name, 29 as numeric_col) as person_1_0_0,
+    struct('Bob' as f_name, 30 as numeric_col) as person_1_0_1,
+    struct('Charlie' as f_name, 31 as numeric_col) as person_1_0_2,
+    struct('Dog the bounty' as f_name, 50 as numeric_col) as person_1_1_0,
+    struct('Dog the bounty' as f_name, 50 as numeric_col) as person_1_1_30,
+    struct('Dog the bounty' as f_name, 50 as numeric_col) as person_1_1_31
 
 )
 

--- a/integration_tests/models/utils/bigquery/expected_combine_column_versions.sql
+++ b/integration_tests/models/utils/bigquery/expected_combine_column_versions.sql
@@ -20,7 +20,10 @@ with prep as (
     coalesce(product_v2.specs.volume) as specs_volume,
     coalesce(product_v2.specs.accessories, product_v1.specs.accessories) as specs_accessories,
     -- Test 4
-    coalesce(product_v2.specs.volume) as product_volume
+    coalesce(product_v2.specs.volume) as product_volume,
+    -- Test 5
+    coalesce(person_1_1_31.f_name, person_1_1_0.f_name, person_1_0_0.f_name) as f_name,
+    coalesce(person_1_1_31.numeric_col, person_1_1_0.numeric_col, person_1_0_0.numeric_col) as numeric_col,
 
   from {{ ref('data_combine_column_versions') }}
 )

--- a/integration_tests/models/utils/bigquery/test_combine_column_versions.sql
+++ b/integration_tests/models/utils/bigquery/test_combine_column_versions.sql
@@ -35,6 +35,10 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
                                                               include_field_alias=false,
                                                               required_fields=['specs.volume']) %}
 
+{% set test_5_actual = snowplow_utils.combine_column_versions(relation=ref('data_combine_column_versions'),
+                                                              column_prefix='person_1',
+                                                              exclude_versions=['1_0_1', '1_0_2', '1_1_30']) %}
+
 with prep as (
    select
       -- Test 1
@@ -44,7 +48,9 @@ with prep as (
       -- Test 3
       {{ test_3_actual|join(',\n') }},
       -- Test 4
-      {{ test_4_actual|join(',') }} as product_volume
+      {{ test_4_actual|join(',') }} as product_volume,
+      -- Test 5
+      {{ test_5_actual|join(',') }}
 
    from {{ ref('data_combine_column_versions') }} a
 )

--- a/macros/utils/bigquery/combine_column_versions/combine_column_versions.sql
+++ b/macros/utils/bigquery/combine_column_versions/combine_column_versions.sql
@@ -24,7 +24,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
 
   {%- set matched_columns = snowplow_utils.get_columns_in_relation_by_column_prefix(relation, column_prefix) -%}
 
-  {# Removes excluded versions, assuming column name ends with a version of format 'X_X_X' #}
+  {# Removes excluded versions, technically removes any column with that suffix #}
   {%- set filter_columns_by_version = snowplow_utils.exclude_column_versions(matched_columns, exclude_versions) -%}
 
   {%- set flattened_fields_by_col_version = [] -%}

--- a/macros/utils/bigquery/combine_column_versions/exclude_column_versions.sql
+++ b/macros/utils/bigquery/combine_column_versions/exclude_column_versions.sql
@@ -5,12 +5,18 @@ and you may not use this file except in compliance with the Snowplow Personal an
 You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
 #}
 {% macro exclude_column_versions(columns, exclude_versions) %}
+  {% if not exclude_versions %}
+    {{ return(columns) }}
+  {% endif %}
+
   {%- set filtered_columns_by_version = [] -%}
   {% for column in columns %}
-    {%- set col_version = column.name[-5:] -%}
-    {% if col_version not in exclude_versions %}
-      {% do filtered_columns_by_version.append(column) %}
-    {% endif %}
+  {# Remove columns that end with the version we want to exclude #}
+    {% for version in exclude_versions %}
+      {% if not column.name.endswith(version) %}
+        {% do filtered_columns_by_version.append(column) %}
+      {% endif %}
+    {% endfor %}
   {% endfor %}
 
   {{ return(filtered_columns_by_version) }}


### PR DESCRIPTION
## Description

This PR fixes an issue where the exclude versions was limited to only 1 digit for each part of the version number.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
https://snplow.atlassian.net/browse/PE-6264

## Checklist
- [ ] 🎉 I have verified that these changes work in Redshift
- [ ] 💣 Is your change a breaking change?
- [ ] 📖 I have updated the CHANGELOG.md

### Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?
- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [x] 🙅 no documentation needed
