### PR TITLE
Allow for allow_null_dvce_tstamps var

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ This macro generates the sessions lifecycle manifest table that Snowplow leverag
 - `event_limits_table`: The name of the table where your Snowplow event limits are stored.
 - `incremental_manifest_table`: The name of the incremental manifest table.
 - `package_name`: The name of the package you are running this macro under.
+- `allow_null_dvce_tstamps`: A boolean to allow nulls for the dvce_created_tstamp or dvce_sent_tstamp fields for certain tracker users when it is safe to bypass the events sent late check/filter using days_late_allowed
 
 **Usage:**
 
@@ -829,6 +830,7 @@ This macro generates the events this run table that Snowplow leverages.
 - `snowplow_events_table`: The name of your events table where your events land.
 - `entities_or_sdes`: In Redshift & Postgres, due to the shredded table design (meaning each context is loaded separately into a table), you need to specify which contexts you want to be included in the snowplow_base_events_this_run table, which you can do using this variable. This needs to be an array of key:value maps with the following properties: `name`, `prefix`, `alias`, `single_entity`
 - `custom_sql`: Any custom SQL you want to include within your `events_this_run` table
+- `allow_null_dvce_tstamps`: A boolean to allow nulls for the dvce_created_tstamp or dvce_sent_tstamp fields for certain tracker users when it is safe to bypass the events sent late check/filter using days_late_allowed
 
 **Usage:**
 


### PR DESCRIPTION
## Description
Some of our trackers (e.g specific older versions of the AMP tracker or the Pixel tracker) do not send any value for `dvce_created_tstamp` and `dvce_sent_tstamp`. While the snowplow sessionization logic adds a filter to prevent potentially large table scans and reprocessing old sessions that are sent exceptionally late (e.g due to a bot) for such cases this should not matter as there is  no retry on those trackers: events are sent right after tracking them or not at all.

This PR allows for setting a variable to coalesce the value with `collector_tstamp`, which should be available in all trackers.

This should not be a breaking change as it is added as an optional parameter. So far it has been tested locally and in this Unified [PR](https://github.com/snowplow/dbt-snowplow-unified/pull/74).

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Checklist
- [ ] 💣 Is your change a breaking change?
- [ ] 📖 I have updated the CHANGELOG.md

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?




