### PR TITLE
Release/snowplow utils/0.16.8

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -110,7 +110,7 @@ jobs:
       # Install latest patch version. Upgrade if cache contains old patch version.
       - name: Install dependencies
         run: |
-          pip install --upgrade pip wheel setuptools
+          pip install wheel setuptools
           pip install -Iv dbt-${{ matrix.warehouse }}==${{ matrix.dbt_version }} --upgrade
           dbt deps
         if: ${{matrix.warehouse != 'spark'}}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+snowplow-utils 0.16.8 (2024-07-29)
+---------------------------------------
+## Summary
+This release extends support for those users who would like to use the Snowplow incremental base macros but are using specific older versions of the AMP tracker or the Pixel tracker which do not send dvce_created / dvce_sent_tstamp fields. It also fixes a bug in the apply_grands() macro when the users does not have a grants config defined.
+
+## Features
+- Add allow_null_dvce_tstamps var
+
+## Fixes
+- Add default for grant_config macro
+
+## Upgrading
+To upgrade, bump the package version in your `packages.yml` file.
+
 snowplow-utils 0.16.7 (2024-06-10)
 ---------------------------------------
 ## Summary

--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ This macro generates the sessions lifecycle manifest table that Snowplow leverag
 - `event_limits_table`: The name of the table where your Snowplow event limits are stored.
 - `incremental_manifest_table`: The name of the incremental manifest table.
 - `package_name`: The name of the package you are running this macro under.
+- `allow_null_dvce_tstamps`: A boolean to allow nulls for the dvce_created_tstamp or dvce_sent_tstamp fields for certain tracker users when it is safe to bypass the events sent late check/filter using days_late_allowed
 
 **Usage:**
 
@@ -829,6 +830,7 @@ This macro generates the events this run table that Snowplow leverages.
 - `snowplow_events_table`: The name of your events table where your events land.
 - `entities_or_sdes`: In Redshift & Postgres, due to the shredded table design (meaning each context is loaded separately into a table), you need to specify which contexts you want to be included in the snowplow_base_events_this_run table, which you can do using this variable. This needs to be an array of key:value maps with the following properties: `name`, `prefix`, `alias`, `single_entity`
 - `custom_sql`: Any custom SQL you want to include within your `events_this_run` table
+- `allow_null_dvce_tstamps`: A boolean to allow nulls for the dvce_created_tstamp or dvce_sent_tstamp fields for certain tracker users when it is safe to bypass the events sent late check/filter using days_late_allowed
 
 **Usage:**
 

--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ This macro generates the sessions lifecycle manifest table that Snowplow leverag
 - `user_identifiers`: An array of key:value maps of user identifiers that have at least the following properties: `schema`, `field`.
 - `user_sql`: A SQL statement that will be used to create the `user_identifier`.
 - `quarantined_sessions`: The name of the table containing all quarantined sessions.
-- `derived_tstamp_partitioned`: Whether or not to partition on derived timestamps (BQ only).
+- `derived_tstamp_partitioned`: Whether or not the events table is partitioned on derived timestamps (BQ only), used for optimization.
 - `days_late_allowed`: The maximum allowed number of days between the event creation and it being sent to the collector.
 - `max_session_days`: The maximum allowed session length in days.
 - `app_ids`: A list of app_ids to filter the events table on for processing within the package.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils'
-version: '0.16.7'
+version: '0.16.8'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils_integration_tests'
-version: '0.16.7'
+version: '0.16.8'
 config-version: 2
 
 profile: 'integration_tests'

--- a/macros/incremental_hooks/apply_grants.sql
+++ b/macros/incremental_hooks/apply_grants.sql
@@ -6,7 +6,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
 #}
 
 {# Note this does not work for bigquery due to the role/IAM type approach they have to grants, so BQ users should not supply values to this var #}
-{% macro default__apply_grants(relation, grant_config, should_revoke=True) %}
+{% macro default__apply_grants(relation, grant_config={}, should_revoke=True) %}
     {# 
         We only want to enforce this if the package user is managing grants this way - if they are doing it in database we should 
         pass {} so that it's a no-op 


### PR DESCRIPTION
## Description
This release extends support for those users who would like to use the Snowplow incremental base macros but are using specific older versions of the AMP tracker or the Pixel tracker which do not send dvce_created / dvce_sent_tstamp fields. It also fixes a bug in the apply_grands() macro when the users does not have a grants config defined.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
[<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->](https://www.notion.so/keep-in-the-snow/5058060fa44841989620e4cd306404ca?v=86817f2dc72942c4aee757a0b6756202&p=9cc22e6c952c4c14a22c573531cf4d27&pm=s)

## Checklist
- [ ] 💣 Is your change a breaking change?
- [ ] 📖 I have updated the CHANGELOG.md

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [x] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation/pull/967/files) PR if applicable (Link here if required)
- [ ] 🙅 no documentation needed


## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have changed the release date in the CHANGELOG.md 

