### PR TITLE
Release/snowplow utils/0.17.2

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Python setup
         uses: actions/setup-python@v4
         with:
-         python-version: "3.8.x"
+         python-version: "3.9.x"
 
       - name: Pip cache
         uses: actions/cache@v3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+snowplow-utils 0.17.2 (2025-05-08)
+---------------------------------------
+## Summary
+This release is for those `Snowflake` and `Postgres` Snowplow dbt package users who are using `delete+insert incremental strategy`, are on dbt v1.9.4+ and are reliant on the Snowplow optimize for incremental runs. Due to a recent dbt [change](https://github.com/dbt-labs/dbt-adapters/pull/910) in the original macro we extend/overwrite for the incremental optimization a bug was introduced which this patch release addresses to insure compatibility across versions.
+
+## Fix
+- Fix broken delete insert override for new dbt versions
+
+## Under the hood
+- Allow latest dbt version in pr tests
+
+## Upgrading
+Update the snowplow-utils version in your `packages.yml` file.
+
 snowplow-utils 0.17.1 (2024-10-29)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils'
-version: '0.17.1'
+version: '0.17.2'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_utils_integration_tests'
-version: '0.17.1'
+version: '0.17.2'
 config-version: 2
 
 profile: 'integration_tests'

--- a/macros/materializations/base_incremental/common/get_merge_sql.sql
+++ b/macros/materializations/base_incremental/common/get_merge_sql.sql
@@ -99,7 +99,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
         {% set lower_limit, upper_limit = limits[0], limits[1] %}
         -- use those calculated min + max values to limit 'target' scan, to only the days with new data
         {% set predicate_override %}
-            {{target_tb}}.{{ date_column }} between '{{ lower_limit }}' and '{{ upper_limit }}'
+            {{ date_column }} between '{{ lower_limit }}' and '{{ upper_limit }}'
         {% endset %}
     {% endif %}
     {# Combine predicates with user provided ones #}


### PR DESCRIPTION
## Description
`Snowflake` and `Postgres` Snowplow dbt package users who are using `delete+insert incremental strategy` from dbt v1.9.4 onwards (and are reliant on the snowplow optimize for incremental runs) will find errors starting in their `snowplow_base_session_lifecycle_manifest` tables due to a recent dbt [change](https://github.com/dbt-labs/dbt-adapters/pull/910) in the original macro we extend/overwrite. This PR aims at fixing that issue while maintaining backwards compatibility.

I'm also allowing for the latest dbt version to pass through for the integration tests as they seem to have been fixed due to python compatibility.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert


## Checklist
- [ ] 💣 Is your change a breaking change?
- [x] 📖 I have updated the CHANGELOG.md

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [ ] 🙅 no documentation needed


## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have changed the release date in the CHANGELOG.md 

