### PR TITLE
Let dbt-adapters handle routing to appropriate `get_delete_insert_merge_sql` macro

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+snoplow-utils X.X.X (20XX-XX-XX)
+---------------------------------------
+## Summary
+
+## Fix
+- Fix broken delete insert for redshift
+
 snowplow-utils 0.17.2 (2025-05-08)
 ---------------------------------------
 ## Summary

--- a/macros/materializations/base_incremental/common/get_merge_sql.sql
+++ b/macros/materializations/base_incremental/common/get_merge_sql.sql
@@ -108,7 +108,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
     {% if target.type in ['databricks', 'spark'] -%}
         {% set merge_sql = spark__get_delete_insert_merge_sql(target_tb, source, unique_key, dest_columns, predicates) %}
     {% else %}
-        {% set merge_sql = dbt.default__get_delete_insert_merge_sql(target_tb, source, unique_key, dest_columns, predicates) %}
+        {% set merge_sql = dbt.get_delete_insert_merge_sql(target_tb, source, unique_key, dest_columns, predicates) %}
     {% endif %}
 
     {{ return(merge_sql) }}


### PR DESCRIPTION
resolves #204

## Description

Previously what was being used was `dbt.default_get_delete_insert_merge_sql`. This _always_ got the "default" delete insert merge sql. That was bad because some adapters specifically don't work with the default macro, and implement their own under the hood. By instead using `dbt.get_delete_insert_merge_sql` we allow the "normal" macro resolution to occur.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
#204 

## Checklist
- [ ] 💣 Is your change a breaking change?
- [X] 📖 I have updated the CHANGELOG.md

### Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [X] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
No


## [optional] What gif best describes this PR or how it makes you feel?

![timeforpizza](https://github.com/user-attachments/assets/a5470c77-caa6-4e76-8cdc-5752bec3d10d)

<!-- 
## Release Only Checklist
- [ ] I have updated the version number in all relevant places
- [ ] I have changed the release date in the CHANGELOG.md 
-->
