### PR TITLE
Fix unsupported macro argument types for dbt Fusion

### DIFF
--- a/macros/utils/schema.yml
+++ b/macros/utils/schema.yml
@@ -5,7 +5,7 @@ macros:
     description: '{{ doc("macro_app_id_filter") }}'
     arguments:
       - name: app_ids
-        type: list
+        type: list[any]
         description: List of app_ids to filter to include
   - name: get_columns_in_relation_by_column_prefix
     description: '{{ doc("macro_get_columns_in_relation_by_column_prefix") }}'
@@ -75,7 +75,7 @@ macros:
     description: '{{ doc("macro_print_list") }}'
     arguments:
       - name: list
-        type: array
+        type: list[any]
         description: Array object to print the (quoted) items of
       - name: separator
         type: string


### PR DESCRIPTION
Fusion (dbt1506) rejects bare `list` and `array` in macro `arguments:` schemas — supported list-like types must be parameterized. Replace with `list[any]` in macros/utils/schema.yml for app_id_filter.app_ids and print_list.list. Core dbt treats the type field as free-form metadata and is unaffected.
